### PR TITLE
hotfix(db): Change simplify eventStatus schema and use native bun-sql instead of node-postgres

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,5 +73,8 @@
   // ── Emmet ──────────────────────────────────
   "emmet.includeLanguages": {
     "svelte": "html"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,21 +1,9 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/bun-sql';
 import * as schema from './schema';
 
 const connectionString = process.env.DATABASE_URL;
-
 if (!connectionString) {
   throw new Error('❌ DATABASE_URL không tồn tại trong file .env');
 }
 
-// Khởi tạo connection pool tới NeonDB
-// BẮT BUỘC dùng Pooled Connection String của Neon
-const pool = new Pool({
-  connectionString: connectionString,
-  max: 100,
-  idleTimeoutMillis: 30000,
-  connectionTimeoutMillis: 2000,
-});
-
-// Export singleton instance của DB
-export const db = drizzle(pool, { schema });
+export const db = drizzle(connectionString, { schema });

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
   boolean,
   date,
@@ -16,12 +17,7 @@ import {
 // ── Enums ──────────────────────────────────────
 export const roleEnum = pgEnum('role', ['admin', 'customer']);
 export const genderEnum = pgEnum('gender', ['male', 'female', 'other']);
-export const eventStatusEnum = pgEnum('event_status', [
-  'draft',
-  'published',
-  'cancelled',
-  'completed',
-]);
+export const eventStatusEnum = pgEnum('event_status', ['draft', 'published']);
 export const seatStatusEnum = pgEnum('seat_status', ['available', 'locked', 'sold']);
 export const orderStatusEnum = pgEnum('order_status', ['pending', 'paid', 'cancelled']);
 
@@ -50,8 +46,6 @@ export const events = pgTable('events', {
   eventDate: timestamp('event_date', { withTimezone: true }).notNull(),
   bannerImageUrl: varchar('banner_image_url', { length: 500 }),
   status: eventStatusEnum('status').notNull().default('draft'),
-  saleStartAt: timestamp('sale_start_at', { withTimezone: true }),
-  saleEndAt: timestamp('sale_end_at', { withTimezone: true }),
   createdBy: integer('created_by')
     .notNull()
     .references(() => users.id),
@@ -116,7 +110,9 @@ export const orders = pgTable(
   },
   (table) => [
     index('idx_orders_user').on(table.userId, table.status),
-    index('idx_orders_expires').on(table.status, table.expiresAt),
+    index('idx_orders_expires')
+      .on(table.status, table.expiresAt)
+      .where(sql`${table.status} = 'pending'`),
   ],
 );
 // ── Order Items ────────────────────────────────

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -72,7 +72,6 @@ export async function seed() {
       eventDate: new Date('2026-06-15T19:00:00Z'),
       bannerImageUrl: 'https://picsum.photos/seed/rock/800/400',
       status: 'published',
-      saleStartAt: new Date('2026-05-01T09:00:00Z'),
       createdBy: admin.id,
     })
     .returning();
@@ -92,7 +91,6 @@ export async function seed() {
       eventDate: new Date('2026-07-20T20:00:00Z'),
       bannerImageUrl: 'https://picsum.photos/seed/edm/800/400',
       status: 'published',
-      saleStartAt: new Date('2026-06-01T09:00:00Z'),
       createdBy: admin.id,
     })
     .returning();


### PR DESCRIPTION
## Mô tả

Xoá 2 status không cần thiết của event và dùng native bun-sql để connect database

Fix #3 

## Loại thay đổi

- [x] 🐛 Bug fix


## Screenshots / Demo

<!-- Paste ảnh hoặc video nếu có thay đổi UI. Xóa mục này nếu không cần. -->

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined event status management to draft and published states only.
  * Removed sale date scheduling fields from events.
  * Updated backend database infrastructure.

* **Chores**
  * Configured development environment for TypeScript formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->