### PR TITLE
feat(schema): enhance seat layout schema and add flex layout support

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,3 +1,4 @@
+// src/lib/server/db/schema.ts
 import { sql } from 'drizzle-orm';
 import {
   boolean,
@@ -18,7 +19,7 @@ import {
 export const roleEnum = pgEnum('role', ['admin', 'customer']);
 export const genderEnum = pgEnum('gender', ['male', 'female', 'other']);
 export const eventStatusEnum = pgEnum('event_status', ['draft', 'published']);
-export const seatStatusEnum = pgEnum('seat_status', ['available', 'locked', 'sold']);
+export const seatStatusEnum = pgEnum('seat_status', ['available', 'locked', 'sold', 'disabled']);
 export const orderStatusEnum = pgEnum('order_status', ['pending', 'paid', 'cancelled']);
 
 // ── Users ──────────────────────────────────────
@@ -63,6 +64,10 @@ export const seatSections = pgTable('seat_sections', {
   rows: integer('rows').notNull(),
   cols: integer('cols').notNull(),
   price: decimal('price', { precision: 12, scale: 2 }).notNull(),
+  layoutX: integer('layout_x').notNull().default(0),
+  layoutY: integer('layout_y').notNull().default(0),
+  startRowIndex: integer('start_row_index').notNull().default(0),
+  startColIndex: integer('start_col_index').notNull().default(1),
   sortOrder: integer('sort_order').notNull().default(0),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });
@@ -85,7 +90,7 @@ export const seats = pgTable(
     lockedAt: timestamp('locked_at', { withTimezone: true }),
   },
   (table) => [
-    uniqueIndex('idx_seats_unique').on(table.sectionId, table.rowLabel, table.colNumber),
+    uniqueIndex('uq_seat_label_per_event').on(table.eventId, table.rowLabel, table.colNumber),
     index('idx_seats_event_status').on(table.eventId, table.status),
   ],
 );
@@ -115,6 +120,7 @@ export const orders = pgTable(
       .where(sql`${table.status} = 'pending'`),
   ],
 );
+
 // ── Order Items ────────────────────────────────
 export const orderItems = pgTable('order_items', {
   id: serial('id').primaryKey(),

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -1,36 +1,80 @@
+// src/lib/server/db/seed.ts
 import { db } from '$lib/server/db';
-import { events, seatSections, seats, users } from '$lib/server/db/schema';
+import { events, orderItems, orders, seatSections, seats, users } from '$lib/server/db/schema';
 import * as argon2 from 'argon2';
+import { sql } from 'drizzle-orm';
+
+// ── Helpers ────────────────────────────────────
 
 /**
- * Mock password-hashing helper used for development and testing.
- *
- * This function does not perform real cryptographic hashing; it returns a deterministic placeholder derived from the input.
- *
- * @param plain - The plaintext password to hash
- * @returns The mocked hashed string in the form `hashed_<plain>`
+ * Hash a plaintext password using argon2id.
  */
 export async function hashPassword(password: string): Promise<string> {
   return await argon2.hash(password, { type: argon2.argon2id });
 }
 
 /**
+ * Convert a 0-based index to a row label.
+ * 0→A, 1→B, 25→Z, 26→AA, 27→AB
+ */
+function getRowLabel(index: number): string {
+  let label = '';
+  let i = index;
+  while (i >= 0) {
+    label = String.fromCharCode(65 + (i % 26)) + label;
+    i = Math.floor(i / 26) - 1;
+  }
+  return label;
+}
+
+// ── Types ──────────────────────────────────────
+
+interface SectionSeed {
+  name: string;
+  rows: number;
+  cols: number;
+  price: string;
+  layoutX: number;
+  layoutY: number;
+  startRowIndex: number;
+  startColIndex: number;
+  sortOrder: number;
+  disabledSeats?: string[];
+}
+
+// ── Seed ───────────────────────────────────────
+
+/**
  * Seed the development database with initial users, events, sections, and seats.
  *
- * Inserts an admin user and several customer users, creates two sample events
- * ("Rock Festival 2026" and "EDM Night Saigon"), and for each event creates
- * seat sections and generates seat rows/columns marked as available. Logs
- * progress and a summary of seeded seat counts.
+ * Cleans all existing data first (FK-safe order), then inserts:
+ * - 1 admin + 5 customers
+ * - Event 1: "Rock Festival 2026" — VIP split Left/Right + Standard (flex layout demo)
+ * - Event 2: "EDM Night Saigon" — 3 sections with disabled seats demo
  */
 export async function seed() {
   console.log('🌱 Bắt đầu seed data...');
 
-  // await db.delete(seats);
-  // await db.delete(seatSections);
-  // await db.delete(events);
-  // await db.delete(users);
+  // ════════════════════════════════════════════
+  // 🧹 Cleanup — xóa data cũ theo thứ tự FK (con → cha)
+  // ════════════════════════════════════════════
+  console.log('🧹 Cleaning existing data...');
+  await db.delete(orderItems);
+  await db.delete(orders);
+  await db.delete(seats);
+  await db.delete(seatSections);
+  await db.delete(events);
+  await db.delete(users);
 
-  // ── Admin ──
+  // Reset auto-increment sequences để ID bắt đầu từ 1
+  await db.execute(sql`ALTER SEQUENCE users_id_seq RESTART WITH 1`);
+  await db.execute(sql`ALTER SEQUENCE events_id_seq RESTART WITH 1`);
+  await db.execute(sql`ALTER SEQUENCE seat_sections_id_seq RESTART WITH 1`);
+  await db.execute(sql`ALTER SEQUENCE seats_id_seq RESTART WITH 1`);
+  await db.execute(sql`ALTER SEQUENCE orders_id_seq RESTART WITH 1`);
+  await db.execute(sql`ALTER SEQUENCE order_items_id_seq RESTART WITH 1`);
+
+  // ── Admin ──────────────────────────────────
   const [admin] = await db
     .insert(users)
     .values({
@@ -63,7 +107,19 @@ export async function seed() {
     });
   }
 
-  // ── Event 1: Rock Festival ──
+  // ── Event 1: Rock Festival — VIP chia Trái/Phải + Standard ──
+  // Demo: flex layout với lối đi giữa 2 block VIP
+  //
+  // [SÂN KHẤU]
+  //
+  // VIP-Trái (A1–A5)   [lối đi]   VIP-Phải (A6–A10)
+  // VIP-Trái (B1–B5)   [lối đi]   VIP-Phải (B6–B10)
+  // VIP-Trái (C1–C5)   [lối đi]   VIP-Phải (C6–C10)
+  //
+  // Standard (D1–D20)
+  // ...
+  // Standard (M1–M20)
+
   const [event1] = await db
     .insert(events)
     .values({
@@ -78,11 +134,55 @@ export async function seed() {
     .returning();
 
   await createSections(event1.id, [
-    { name: 'VIP', rows: 5, cols: 20, price: '2000000', sortOrder: 0 },
-    { name: 'Standard', rows: 10, cols: 30, price: '500000', sortOrder: 1 },
+    {
+      name: 'VIP - Trái',
+      rows: 3,
+      cols: 5,
+      price: '2000000',
+      layoutX: 0,
+      layoutY: 100,
+      startRowIndex: 0, // A
+      startColIndex: 1, // 1–5
+      sortOrder: 0,
+    },
+    {
+      name: 'VIP - Phải',
+      rows: 3,
+      cols: 5,
+      price: '2000000',
+      layoutX: 80, // Cách block trái → tạo lối đi
+      layoutY: 100, // Cùng hàng ngang
+      startRowIndex: 0, // Vẫn A
+      startColIndex: 6, // 6–10 → liền mạch với bên trái
+      sortOrder: 1,
+    },
+    {
+      name: 'Standard',
+      rows: 10,
+      cols: 20,
+      price: '500000',
+      layoutX: 0,
+      layoutY: 250, // Phía sau VIP
+      startRowIndex: 3, // D (nối tiếp sau hàng C của VIP)
+      startColIndex: 1,
+      sortOrder: 2,
+    },
   ]);
 
-  // ── Event 2: EDM Night ──
+  const event1TotalSeats = 3 * 5 + 3 * 5 + 10 * 20; // 230
+
+  // ── Event 2: EDM Night — Có disabled seats ──
+  // Demo: ghế bị vô hiệu hóa do cột chắn tầm nhìn
+  //
+  // Diamond:  A1–A15 (hàng đầu, không bị chắn)
+  //           B1–B15 (B8 disabled — cột chắn)
+  //           C1–C15 (C8 disabled — cột chắn)
+  //
+  // Gold:     D1–D20
+  // ...
+  // Silver:   I1–I25
+  // ...
+
   const [event2] = await db
     .insert(events)
     .values({
@@ -97,34 +197,66 @@ export async function seed() {
     .returning();
 
   await createSections(event2.id, [
-    { name: 'Diamond', rows: 3, cols: 15, price: '3000000', sortOrder: 0 },
-    { name: 'Gold', rows: 5, cols: 20, price: '1500000', sortOrder: 1 },
-    { name: 'Silver', rows: 10, cols: 25, price: '700000', sortOrder: 2 },
+    {
+      name: 'Diamond',
+      rows: 3,
+      cols: 15,
+      price: '3000000',
+      layoutX: 0,
+      layoutY: 50,
+      startRowIndex: 0, // A
+      startColIndex: 1,
+      sortOrder: 0,
+      disabledSeats: ['B8', 'C8'], // Cột chắn tầm nhìn
+    },
+    {
+      name: 'Gold',
+      rows: 5,
+      cols: 20,
+      price: '1500000',
+      layoutX: 0,
+      layoutY: 180,
+      startRowIndex: 3, // D (nối tiếp Diamond)
+      startColIndex: 1,
+      sortOrder: 1,
+    },
+    {
+      name: 'Silver',
+      rows: 10,
+      cols: 25,
+      price: '700000',
+      layoutX: 0,
+      layoutY: 380,
+      startRowIndex: 8, // I (nối tiếp Gold)
+      startColIndex: 1,
+      sortOrder: 2,
+      disabledSeats: ['I13', 'J13', 'K13'], // Cột chắn giữa Silver
+    },
   ]);
 
+  const event2DisabledCount = 2 + 3; // Diamond: 2, Silver: 3
+  const event2TotalSeats = 3 * 15 + 5 * 20 + 10 * 25; // 395 total grid
+  const event2AvailableSeats = event2TotalSeats - event2DisabledCount; // 390 available
+
+  // ── Summary ────────────────────────────────
   console.log('✅ Seed completed!');
-  console.log(`🎟️  Event 1: ${5 * 20 + 10 * 30} = 400 seats`);
-  console.log(`🎟️  Event 2: ${3 * 15 + 5 * 20 + 10 * 25} = 395 seats`);
+  console.log(`🎟️  Event 1: "${event1.title}" — ${event1TotalSeats} seats (VIP split Left/Right)`);
+  console.log(
+    `🎟️  Event 2: "${event2.title}" — ${event2AvailableSeats} available + ${event2DisabledCount} disabled = ${event2TotalSeats} total`,
+  );
 }
 
 /**
  * Create seat sections for an event and insert the corresponding seat records.
  *
- * For each entry in `sections`, inserts a `seatSections` record for the given `eventId`
- * and batch-inserts the generated seats for that section with status `'available'`.
+ * Supports flex seat layout:
+ * - `layoutX`/`layoutY`: position on the canvas (grid units)
+ * - `startRowIndex`/`startColIndex`: offset for row/col numbering
+ * - `disabledSeats`: array of seat labels (e.g. "B4") to mark as disabled
  *
- * @param eventId - The ID of the event to attach sections and seats to
- * @param sections - Array of section descriptors. Each descriptor must include:
- *   - `name`: section name
- *   - `rows`: number of seat rows (row labels start at "A")
- *   - `cols`: number of seats per row (columns numbered from 1)
- *   - `price`: price for the section
- *   - `sortOrder`: ordering index for the section
+ * Seats are batch-inserted in chunks of 1000 for performance.
  */
-async function createSections(
-  eventId: number,
-  sections: { name: string; rows: number; cols: number; price: string; sortOrder: number }[],
-) {
+async function createSections(eventId: number, sections: SectionSeed[]) {
   for (const s of sections) {
     const [section] = await db
       .insert(seatSections)
@@ -134,29 +266,43 @@ async function createSections(
         rows: s.rows,
         cols: s.cols,
         price: s.price,
+        layoutX: s.layoutX,
+        layoutY: s.layoutY,
+        startRowIndex: s.startRowIndex,
+        startColIndex: s.startColIndex,
         sortOrder: s.sortOrder,
       })
       .returning();
 
-    // Sinh ma trận ghế
+    // Sinh ma trận ghế với offset + disabled support
+    const disabledSet = new Set(s.disabledSeats ?? []);
     const seatValues = [];
+
     for (let r = 0; r < s.rows; r++) {
-      const rowLabel = String.fromCharCode(65 + r); // A, B, C, D,...
-      for (let c = 1; c <= s.cols; c++) {
+      const rowLabel = getRowLabel(s.startRowIndex + r);
+
+      for (let c = 0; c < s.cols; c++) {
+        const colNumber = s.startColIndex + c;
+        const label = `${rowLabel}${colNumber}`;
+
         seatValues.push({
           sectionId: section.id,
           eventId,
           rowLabel,
-          colNumber: c,
-          status: 'available' as const,
+          colNumber,
+          status: disabledSet.has(label) ? ('disabled' as const) : ('available' as const),
         });
       }
     }
-    // Batch insert để tối ưu hiệu năng
-    await db.insert(seats).values(seatValues);
+
+    // Batch insert (chunk 1000) để tối ưu hiệu năng
+    for (let i = 0; i < seatValues.length; i += 1000) {
+      await db.insert(seats).values(seatValues.slice(i, i + 1000));
+    }
   }
 }
 
+// ── Entry point ────────────────────────────────
 if (import.meta.main) {
   seed()
     .then(() => {

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -1,4 +1,5 @@
 // src/lib/shared/schemas/event.schema.ts
+import { getRowLabel, parseSeatLabel, rowLabelToIndex } from '$lib/utils/seat-label';
 import { z } from 'zod';
 
 // ── Helpers ────────────────────────────────────
@@ -9,7 +10,7 @@ const req = (msg: string) => ({
 const seatLabelRegex = /^[A-Z]+\d+$/; // A1, B12, AA3...
 
 // ── Section Schema ─────────────────────────────
-const sectionSchema = z.object({
+const baseSectionSchema = z.object({
   name: z.string(req('Tên khu vực là bắt buộc')).min(1, 'Tên khu vực không được trống'),
 
   rows: z
@@ -26,22 +27,65 @@ const sectionSchema = z.object({
 
   price: z.number(req('Giá là bắt buộc')).positive('Giá phải lớn hơn 0'),
 
-  // ── Flex Seat — Layout ──
   layout_x: z.number().int().min(0, 'layout_x không được âm').default(0),
-
   layout_y: z.number().int().min(0, 'layout_y không được âm').default(0),
 
-  // ── Flex Seat — Offset ──
   start_row_index: z.number().int().min(0, 'start_row_index không được âm').default(0),
-
   start_col_index: z.number().int().min(1, 'start_col_index phải >= 1').default(1),
 
-  // ── Disabled Seats ──
   disabled_seats: z
     .array(z.string().regex(seatLabelRegex, 'Seat label phải có dạng A1, B12, AA3...'))
     .default([]),
 
   sort_order: z.number().int().min(0).default(0),
+});
+
+// Thêm cross-field validation: disabled_seats phải nằm trong phạm vi section
+const sectionSchema = baseSectionSchema.superRefine((section, ctx) => {
+  if (!section.disabled_seats || section.disabled_seats.length === 0) return;
+
+  const startRow = section.start_row_index;
+  const endRow = startRow + section.rows - 1;
+  const startCol = section.start_col_index;
+  const endCol = startCol + section.cols - 1;
+
+  // Tính valid row labels để hiển thị trong error message
+  const minRowLabel = getRowLabel(startRow);
+  const maxRowLabel = getRowLabel(endRow);
+
+  const invalidSeats: string[] = [];
+
+  for (const label of section.disabled_seats) {
+    const parsed = parseSeatLabel(label);
+
+    if (!parsed) {
+      invalidSeats.push(label);
+      continue;
+    }
+
+    const rowIndex = rowLabelToIndex(parsed.rowLabel);
+
+    if (
+      rowIndex < startRow ||
+      rowIndex > endRow ||
+      parsed.colNumber < startCol ||
+      parsed.colNumber > endCol
+    ) {
+      invalidSeats.push(label);
+    }
+  }
+
+  if (invalidSeats.length > 0) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['disabled_seats'],
+      message:
+        `Các ghế không nằm trong phạm vi section (` +
+        `hàng ${minRowLabel}-${maxRowLabel}, ` +
+        `cột ${startCol}-${endCol}): ` +
+        `${invalidSeats.join(', ')}`,
+    });
+  }
 });
 
 // ── Event Schema ───────────────────────────────
@@ -72,7 +116,7 @@ export const createEventSchema = z
     }, 'Tổng số ghế không được vượt quá 50,000'),
   );
 
-// ── Update Sections Schema (cho PUT endpoint) ──
+// ── Update Sections Schema ─────────────────────
 export const updateSectionsSchema = z.object({
   sections: z.array(sectionSchema).min(1, 'Phải có ít nhất 1 khu vực ghế'),
 });

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -1,36 +1,83 @@
 // src/lib/shared/schemas/event.schema.ts
 import { z } from 'zod';
 
+// ── Helpers ────────────────────────────────────
 const req = (msg: string) => ({
   error: (issue: { input: unknown }) => (issue.input === undefined ? msg : undefined),
 });
 
+const seatLabelRegex = /^[A-Z]+\d+$/; // A1, B12, AA3...
+
+// ── Section Schema ─────────────────────────────
 const sectionSchema = z.object({
   name: z.string(req('Tên khu vực là bắt buộc')).min(1, 'Tên khu vực không được trống'),
-  rows: z.number(req('Số hàng là bắt buộc')).int('Số hàng phải là số nguyên').min(1).max(50),
-  cols: z.number(req('Số cột là bắt buộc')).int('Số cột phải là số nguyên').min(1).max(50),
+
+  rows: z
+    .number(req('Số hàng là bắt buộc'))
+    .int('Số hàng phải là số nguyên')
+    .min(1, 'Tối thiểu 1 hàng')
+    .max(50, 'Tối đa 50 hàng'),
+
+  cols: z
+    .number(req('Số cột là bắt buộc'))
+    .int('Số cột phải là số nguyên')
+    .min(1, 'Tối thiểu 1 cột')
+    .max(100, 'Tối đa 100 cột'),
+
   price: z.number(req('Giá là bắt buộc')).positive('Giá phải lớn hơn 0'),
+
+  // ── Flex Seat — Layout ──
+  layout_x: z.number().int().min(0, 'layout_x không được âm').default(0),
+
+  layout_y: z.number().int().min(0, 'layout_y không được âm').default(0),
+
+  // ── Flex Seat — Offset ──
+  start_row_index: z.number().int().min(0, 'start_row_index không được âm').default(0),
+
+  start_col_index: z.number().int().min(1, 'start_col_index phải >= 1').default(1),
+
+  // ── Disabled Seats ──
+  disabled_seats: z
+    .array(z.string().regex(seatLabelRegex, 'Seat label phải có dạng A1, B12, AA3...'))
+    .default([]),
+
   sort_order: z.number().int().min(0).default(0),
 });
 
-export const createEventSchema = z.object({
-  title: z
-    .string(req('Tên sự kiện là bắt buộc'))
-    .min(5, 'Tên sự kiện tối thiểu 5 ký tự')
-    .max(200, 'Tên sự kiện tối đa 200 ký tự'),
+// ── Event Schema ───────────────────────────────
+export const createEventSchema = z
+  .object({
+    title: z
+      .string(req('Tên sự kiện là bắt buộc'))
+      .min(5, 'Tên sự kiện tối thiểu 5 ký tự')
+      .max(200, 'Tên sự kiện tối đa 200 ký tự'),
 
-  description: z.string(req('Mô tả là bắt buộc')).min(1, 'Mô tả không được trống'),
-  venue: z.string(req('Địa điểm là bắt buộc')).min(1, 'Địa điểm không được trống'),
+    description: z.string(req('Mô tả là bắt buộc')).min(1, 'Mô tả không được trống'),
 
-  event_date: z
-    .string(req('Ngày sự kiện là bắt buộc'))
-    .pipe(z.iso.datetime({ offset: true }))
-    .check(z.refine((val) => new Date(val) > new Date(), 'Ngày sự kiện phải trong tương lai')),
+    venue: z.string(req('Địa điểm là bắt buộc')).min(1, 'Địa điểm không được trống'),
 
-  banner_image_url: z.url('URL ảnh không hợp lệ').optional().or(z.literal('')),
+    event_date: z
+      .string(req('Ngày sự kiện là bắt buộc'))
+      .pipe(z.iso.datetime({ offset: true }))
+      .check(z.refine((val) => new Date(val) > new Date(), 'Ngày sự kiện phải trong tương lai')),
 
+    banner_image_url: z.url('URL ảnh không hợp lệ').optional().or(z.literal('')),
+
+    sections: z.array(sectionSchema).min(1, 'Phải có ít nhất 1 khu vực ghế'),
+  })
+  .check(
+    z.refine((data) => {
+      const totalSeats = data.sections.reduce((sum, s) => sum + s.rows * s.cols, 0);
+      return totalSeats <= 50_000;
+    }, 'Tổng số ghế không được vượt quá 50,000'),
+  );
+
+// ── Update Sections Schema (cho PUT endpoint) ──
+export const updateSectionsSchema = z.object({
   sections: z.array(sectionSchema).min(1, 'Phải có ít nhất 1 khu vực ghế'),
 });
 
+// ── Types ──────────────────────────────────────
 export type CreateEventInput = z.infer<typeof createEventSchema>;
+export type UpdateSectionsInput = z.infer<typeof updateSectionsSchema>;
 export type SectionInput = z.infer<typeof sectionSchema>;

--- a/src/lib/utils/seat-label.test.ts
+++ b/src/lib/utils/seat-label.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'bun:test';
+import { getRowLabel, rowLabelToIndex, parseSeatLabel } from './seat-label';
+
+describe('seat-label utils', () => {
+  describe('getRowLabel', () => {
+    it('converts 0-based index to row label correctly', () => {
+      expect(getRowLabel(0)).toBe('A');
+      expect(getRowLabel(1)).toBe('B');
+      expect(getRowLabel(25)).toBe('Z');
+      expect(getRowLabel(26)).toBe('AA');
+      expect(getRowLabel(27)).toBe('AB');
+      expect(getRowLabel(51)).toBe('AZ');
+      expect(getRowLabel(52)).toBe('BA');
+      expect(getRowLabel(701)).toBe('ZZ');
+      expect(getRowLabel(702)).toBe('AAA');
+    });
+  });
+
+  describe('rowLabelToIndex', () => {
+    it('converts row label back to 0-based index correctly', () => {
+      expect(rowLabelToIndex('A')).toBe(0);
+      expect(rowLabelToIndex('B')).toBe(1);
+      expect(rowLabelToIndex('Z')).toBe(25);
+      expect(rowLabelToIndex('AA')).toBe(26);
+      expect(rowLabelToIndex('AB')).toBe(27);
+      expect(rowLabelToIndex('AZ')).toBe(51);
+      expect(rowLabelToIndex('BA')).toBe(52);
+      expect(rowLabelToIndex('ZZ')).toBe(701);
+      expect(rowLabelToIndex('AAA')).toBe(702);
+    });
+  });
+
+  describe('parseSeatLabel', () => {
+    it('parses valid seat labels', () => {
+      expect(parseSeatLabel('A1')).toEqual({ rowLabel: 'A', colNumber: 1 });
+      expect(parseSeatLabel('C10')).toEqual({ rowLabel: 'C', colNumber: 10 });
+      expect(parseSeatLabel('AA25')).toEqual({ rowLabel: 'AA', colNumber: 25 });
+    });
+
+    it('returns null for invalid seat labels', () => {
+      expect(parseSeatLabel('1A')).toBeNull();
+      expect(parseSeatLabel('ABC')).toBeNull();
+      expect(parseSeatLabel('123')).toBeNull();
+      expect(parseSeatLabel('A-1')).toBeNull();
+      expect(parseSeatLabel('')).toBeNull();
+    });
+  });
+});

--- a/src/lib/utils/seat-label.ts
+++ b/src/lib/utils/seat-label.ts
@@ -1,0 +1,36 @@
+// src/lib/utils/seat-label.ts
+
+/**
+ * Convert 0-based index to row label
+ * 0→A, 1→B, 25→Z, 26→AA, 27→AB
+ */
+export function getRowLabel(index: number): string {
+  let label = '';
+  let i = index;
+  while (i >= 0) {
+    label = String.fromCharCode(65 + (i % 26)) + label;
+    i = Math.floor(i / 26) - 1;
+  }
+  return label;
+}
+
+/**
+ * Convert row label back to 0-based index
+ * A→0, B→1, Z→25, AA→26, AB→27
+ */
+export function rowLabelToIndex(label: string): number {
+  let index = 0;
+  for (let i = 0; i < label.length; i++) {
+    index = index * 26 + (label.charCodeAt(i) - 64);
+  }
+  return index - 1;
+}
+
+/**
+ * Parse "C5" → { rowLabel: "C", colNumber: 5 }
+ */
+export function parseSeatLabel(label: string): { rowLabel: string; colNumber: number } | null {
+  const match = label.match(/^([A-Z]+)(\d+)$/);
+  if (!match) return null;
+  return { rowLabel: match[1], colNumber: parseInt(match[2], 10) };
+}

--- a/src/lib/utils/seat-label.ts
+++ b/src/lib/utils/seat-label.ts
@@ -30,7 +30,7 @@ export function rowLabelToIndex(label: string): number {
  * Parse "C5" → { rowLabel: "C", colNumber: 5 }
  */
 export function parseSeatLabel(label: string): { rowLabel: string; colNumber: number } | null {
-  const match = label.match(/^([A-Z]+)(\d+)$/);
+  const match = label.match(/^([A-Z]+)([1-9]\d*)$/);
   if (!match) return null;
   return { rowLabel: match[1], colNumber: parseInt(match[2], 10) };
 }


### PR DESCRIPTION
- Updated seatStatusEnum to include 'disabled' status.
- Added layout properties (layoutX, layoutY, startRowIndex, startColIndex) to seat sections.
- Modified seeding logic to support flex layout with detailed event sections.
- Introduced validation for seat labels in event schema.
- Added utility functions for seat label parsing and conversion.

## Mô tả

Hỗ trợ cấu hình hàng ghế ngồi một cách linh hoạt. Thêm status disabled cho ghế (chỗ ngồi bị hỏng).

Closes #42

## Loại thay đổi

- [x] ✨ Feature mới
- [x] ♻️ Refactor
- [x] 🔧 Chore (config, dependencies,...)

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a new "disabled" seat status
  * Section layout/positioning and row/column offset metadata for flexible seating
  * Seat label utilities (row-label conversion and seat-label parsing)
  * Seeding now supports layout-aware sections and marking seats as disabled

* **Validation**
  * Stronger section validation (expanded limits, disabled-seat label checks, total-seat cap)
  * New API input schema for updating sections

* **Tests**
  * Added comprehensive tests for seat label handling and parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->