### PR TITLE
feat(api): add event listing and detail retrieval endpoints

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -55,22 +55,26 @@ export const events = pgTable('events', {
 });
 
 // ── Seat Sections ──────────────────────────────
-export const seatSections = pgTable('seat_sections', {
-  id: serial('id').primaryKey(),
-  eventId: integer('event_id')
-    .notNull()
-    .references(() => events.id),
-  name: varchar('name', { length: 50 }).notNull(),
-  rows: integer('rows').notNull(),
-  cols: integer('cols').notNull(),
-  price: decimal('price', { precision: 12, scale: 2 }).notNull(),
-  layoutX: integer('layout_x').notNull().default(0),
-  layoutY: integer('layout_y').notNull().default(0),
-  startRowIndex: integer('start_row_index').notNull().default(0),
-  startColIndex: integer('start_col_index').notNull().default(1),
-  sortOrder: integer('sort_order').notNull().default(0),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-});
+export const seatSections = pgTable(
+  'seat_sections',
+  {
+    id: serial('id').primaryKey(),
+    eventId: integer('event_id')
+      .notNull()
+      .references(() => events.id),
+    name: varchar('name', { length: 50 }).notNull(),
+    rows: integer('rows').notNull(),
+    cols: integer('cols').notNull(),
+    price: decimal('price', { precision: 12, scale: 2 }).notNull(),
+    layoutX: integer('layout_x').notNull().default(0),
+    layoutY: integer('layout_y').notNull().default(0),
+    startRowIndex: integer('start_row_index').notNull().default(0),
+    startColIndex: integer('start_col_index').notNull().default(1),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index('idx_seat_sections_event').on(table.eventId)],
+);
 
 // ── Seats ──────────────────────────────────────
 export const seats = pgTable(
@@ -92,6 +96,7 @@ export const seats = pgTable(
   (table) => [
     uniqueIndex('uq_seat_label_per_event').on(table.eventId, table.rowLabel, table.colNumber),
     index('idx_seats_event_status').on(table.eventId, table.status),
+    index('idx_seats_section').on(table.sectionId),
   ],
 );
 

--- a/src/lib/server/services/event.service.ts
+++ b/src/lib/server/services/event.service.ts
@@ -1,10 +1,15 @@
 import { db } from '$lib/server/db';
 import { events, seatSections, seats } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
-import { createEventSchema, updateSectionsSchema, type SectionInput } from '$lib/shared/schemas';
+import {
+  createEventSchema,
+  eventQuerySchema,
+  updateSectionsSchema,
+  type SectionInput,
+} from '$lib/shared/schemas';
 import { validateInput } from '$lib/shared/validation';
 import { getRowLabel } from '$lib/utils/seat-label';
-import { and, eq, type InferInsertModel } from 'drizzle-orm';
+import { and, count, eq, ilike, min, sql, type InferInsertModel } from 'drizzle-orm';
 import { validateEventRequirements } from '../validators/seat-overlap.validator';
 const BATCH_SIZE = 1000;
 
@@ -98,6 +103,156 @@ async function insertSectionsWithSeats(
 }
 
 export const eventService = {
+  async listEvents(params: {
+    q?: string;
+    page?: number;
+    limit?: number;
+    role?: string;
+    userId?: number;
+  }) {
+    const { q, page, limit } = validateInput(eventQuerySchema, params);
+    const { role, userId } = params;
+    const offset = (page - 1) * limit;
+
+    // Build WHERE conditions
+    const conditions = [];
+
+    // Admin sees published + own drafts; others see only published
+    if (role === 'admin' && userId) {
+      conditions.push(
+        sql`(${events.status} = 'published' OR (${events.status} = 'draft' AND ${events.createdBy} = ${userId}))`,
+      );
+    } else {
+      conditions.push(eq(events.status, 'published'));
+    }
+
+    if (q) {
+      conditions.push(ilike(events.title, `%${q}%`));
+    }
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Count total matching events
+    const [{ total }] = await db.select({ total: count() }).from(events).where(whereClause);
+
+    // Query events with seat aggregation
+    const rows = await db
+      .select({
+        id: events.id,
+        title: events.title,
+        venue: events.venue,
+        eventDate: events.eventDate,
+        bannerImageUrl: events.bannerImageUrl,
+        status: events.status,
+        minPrice: min(seatSections.price),
+        totalSeats: count(sql`CASE WHEN ${seats.status} != 'disabled' THEN 1 END`),
+        availableSeats: count(sql`CASE WHEN ${seats.status} = 'available' THEN 1 END`),
+      })
+      .from(events)
+      .leftJoin(seatSections, eq(seatSections.eventId, events.id))
+      .leftJoin(seats, eq(seats.sectionId, seatSections.id))
+      .where(whereClause)
+      .groupBy(events.id)
+      .orderBy(events.eventDate)
+      .limit(limit)
+      .offset(offset);
+
+    return {
+      events: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        venue: r.venue,
+        event_date: r.eventDate,
+        banner_image_url: r.bannerImageUrl,
+        status: r.status,
+        min_price: r.minPrice ? Number(r.minPrice) : 0,
+        total_seats: r.totalSeats,
+        available_seats: r.availableSeats,
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        total_pages: Math.ceil(total / limit),
+      },
+    };
+  },
+
+  async getEventDetail(eventId: number, role?: string, userId?: number) {
+    // 1. Get event basic info
+    const [event] = await db.select().from(events).where(eq(events.id, eventId)).limit(1);
+
+    if (!event) throwError(Errors.NOT_FOUND);
+
+    // Draft events are only visible to the admin who created them
+    if (event.status !== 'published') {
+      if (role !== 'admin' || event.createdBy !== userId) {
+        throwError(Errors.NOT_FOUND);
+      }
+    }
+
+    // 2. Get sections ordered by sort_order
+    const sections = await db
+      .select()
+      .from(seatSections)
+      .where(eq(seatSections.eventId, eventId))
+      .orderBy(seatSections.sortOrder);
+
+    // 3. Aggregate seat counts per section in a single query (avoid N+1)
+    const seatCounts = await db
+      .select({
+        sectionId: seats.sectionId,
+        seatCount: count(),
+        availableCount: count(sql`CASE WHEN ${seats.status} = 'available' THEN 1 END`),
+        disabledCount: count(sql`CASE WHEN ${seats.status} = 'disabled' THEN 1 END`),
+      })
+      .from(seats)
+      .where(eq(seats.eventId, eventId))
+      .groupBy(seats.sectionId);
+
+    // 4. Build a map for O(1) lookup
+    const countsMap = new Map(
+      seatCounts.map((sc) => [
+        sc.sectionId,
+        {
+          seat_count: sc.seatCount,
+          available_count: sc.availableCount,
+          disabled_count: sc.disabledCount,
+        },
+      ]),
+    );
+
+    return {
+      id: event.id,
+      title: event.title,
+      description: event.description,
+      venue: event.venue,
+      event_date: event.eventDate,
+      banner_image_url: event.bannerImageUrl,
+      status: event.status,
+      sections: sections.map((s) => {
+        const counts = countsMap.get(s.id) || {
+          seat_count: 0,
+          available_count: 0,
+          disabled_count: 0,
+        };
+        return {
+          id: s.id,
+          name: s.name,
+          price: Number(s.price),
+          rows: s.rows,
+          cols: s.cols,
+          layout_x: s.layoutX,
+          layout_y: s.layoutY,
+          start_row_index: s.startRowIndex,
+          start_col_index: s.startColIndex,
+          seat_count: counts.seat_count,
+          available_count: counts.available_count,
+          disabled_count: counts.disabled_count,
+        };
+      }),
+    };
+  },
+
   async createEvent(adminId: number, data: unknown) {
     const { sections, ...eventData } = validateInput(createEventSchema, data);
     validateEventRequirements(sections);

--- a/src/lib/server/services/event.service.ts
+++ b/src/lib/server/services/event.service.ts
@@ -3,6 +3,7 @@ import { events, seatSections, seats } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
 import {
   createEventSchema,
+  eventIdSchema,
   eventQuerySchema,
   updateSectionsSchema,
   type SectionInput,
@@ -105,12 +106,16 @@ async function insertSectionsWithSeats(
 export const eventService = {
   async listEvents(params: {
     q?: string;
-    page?: number;
-    limit?: number;
+    page?: string | number;
+    limit?: string | number;
     role?: string;
     userId?: number;
   }) {
-    const { q, page, limit } = validateInput(eventQuerySchema, params);
+    const { q, page, limit } = validateInput(eventQuerySchema, {
+      q: params.q,
+      page: params.page,
+      limit: params.limit,
+    });
     const { role, userId } = params;
     const offset = (page - 1) * limit;
 
@@ -177,7 +182,9 @@ export const eventService = {
     };
   },
 
-  async getEventDetail(eventId: number, role?: string, userId?: number) {
+  async getEventDetail(rawEventId: string | number, role?: string, userId?: number) {
+    const eventId = validateInput(eventIdSchema, rawEventId);
+
     // 1. Get event basic info
     const [event] = await db.select().from(events).where(eq(events.id, eventId)).limit(1);
 

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -134,3 +134,6 @@ export const eventQuerySchema = z.object({
 });
 
 export type EventQueryInput = z.infer<typeof eventQuerySchema>;
+
+// ── Event ID Schema (path param validation) ────
+export const eventIdSchema = z.coerce.number().int().positive('ID sự kiện không hợp lệ');

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -125,3 +125,12 @@ export const updateSectionsSchema = z.object({
 export type CreateEventInput = z.infer<typeof createEventSchema>;
 export type UpdateSectionsInput = z.infer<typeof updateSectionsSchema>;
 export type SectionInput = z.infer<typeof sectionSchema>;
+
+// ── Event Query Schema (Public List API) ───────
+export const eventQuerySchema = z.object({
+  q: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(12),
+});
+
+export type EventQueryInput = z.infer<typeof eventQuerySchema>;

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -5,11 +5,16 @@ import { json } from '@sveltejs/kit';
 
 export const GET = apiHandler(async ({ url, locals }) => {
   const role = locals.user?.role;
+  const userId = locals.user?.id;
+  const pageParam = url.searchParams.get('page');
+  const limitParam = url.searchParams.get('limit');
+
   const data = await eventService.listEvents({
-    q: url.searchParams.get('q') || undefined,
-    page: url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined,
-    limit: url.searchParams.has('limit') ? Number(url.searchParams.get('limit')) : undefined,
+    q: url.searchParams.get('q') ?? undefined,
+    page: pageParam !== null && !Number.isNaN(Number(pageParam)) ? Number(pageParam) : undefined,
+    limit: limitParam !== null && !Number.isNaN(Number(limitParam)) ? Number(limitParam) : undefined,
     role,
+    userId,
   });
   return json({ data });
 });

--- a/src/routes/api/events/+server.ts
+++ b/src/routes/api/events/+server.ts
@@ -3,6 +3,17 @@ import { apiHandler } from '$lib/server/handler';
 import { eventService } from '$lib/server/services/event.service';
 import { json } from '@sveltejs/kit';
 
+export const GET = apiHandler(async ({ url, locals }) => {
+  const role = locals.user?.role;
+  const data = await eventService.listEvents({
+    q: url.searchParams.get('q') || undefined,
+    page: url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined,
+    limit: url.searchParams.has('limit') ? Number(url.searchParams.get('limit')) : undefined,
+    role,
+  });
+  return json({ data });
+});
+
 export const POST = apiHandler(async ({ request, locals }) => {
   const admin = requireAdmin(locals);
   const body = await request.json();

--- a/src/routes/api/events/[id]/+server.ts
+++ b/src/routes/api/events/[id]/+server.ts
@@ -4,6 +4,7 @@ import { json } from '@sveltejs/kit';
 
 export const GET = apiHandler(async ({ params, locals }) => {
   const role = locals.user?.role;
-  const data = await eventService.getEventDetail(Number(params.id), role);
+  const userId = locals.user?.id;
+  const data = await eventService.getEventDetail(Number(params.id), role, userId);
   return json({ data });
 });

--- a/src/routes/api/events/[id]/+server.ts
+++ b/src/routes/api/events/[id]/+server.ts
@@ -1,0 +1,9 @@
+import { apiHandler } from '$lib/server/handler';
+import { eventService } from '$lib/server/services/event.service';
+import { json } from '@sveltejs/kit';
+
+export const GET = apiHandler(async ({ params, locals }) => {
+  const role = locals.user?.role;
+  const data = await eventService.getEventDetail(Number(params.id), role);
+  return json({ data });
+});


### PR DESCRIPTION
## Mô tả

Thêm endpoint API và sửa service để lấy được danh sách sự kiện (hỗ trợ tìm kiếm theo tên, phân trang), chi tiết sự kiện.

Closes #9

## Loại thay đổi

- [x] ✨ Feature mới
## Screenshots / Demo

<img width="2054" height="1416" alt="image" src="https://github.com/user-attachments/assets/9b1c2161-1c68-4b33-aeb0-96afacb28f0b" />

<img width="2061" height="1236" alt="image" src="https://github.com/user-attachments/assets/05d98729-dfb4-4b5e-a2b4-dd3dd352383b" />

<img width="2690" height="1625" alt="image" src="https://github.com/user-attachments/assets/dbbcbe14-901c-49e0-aab2-c8b676dbd169" />

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)
