### PR TITLE
refactor(db): add prefix to seat label

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/montserrat": "^5.2.8",
         "@internationalized/date": "^3.12.0",
-        "@lucide/svelte": "^1.7.0",
+        "@lucide/svelte": "^1.8.0",
         "@sveltejs/kit": "^2.57.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/typography": "^0.5.19",
@@ -190,7 +190,7 @@
 
     "@layerstack/utils": ["@layerstack/utils@2.0.0-next.18", "", { "dependencies": { "d3-array": "^3.2.4", "d3-time": "^3.1.0", "d3-time-format": "^4.1.0" } }, "sha512-EYILHpfBRYMMEahajInu9C2AXQom5IcAEdtCeucD3QIl/fdDgRbtzn6/8QW9ewumfyNZetdUvitOksmI1+gZYQ=="],
 
-    "@lucide/svelte": ["@lucide/svelte@1.7.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-YytBKOUBGox7yWcykZnYxOkn5WpR5G1qYXLYXV/j1B79SOTTEKzB+s5yF5Rq9l9OkweDStNH2b4yTqfvhEhV8g=="],
+    "@lucide/svelte": ["@lucide/svelte@1.8.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-+zYQUKqEOVP5lxbGmxL1OVgGMQtRK91eIJ0bR+3Cr1ts4oQEsQfxyzzd5X47psJlblAuGFrl2xm4YuATjR9oaA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/montserrat": "^5.2.8",
     "@internationalized/date": "^3.12.0",
-    "@lucide/svelte": "^1.7.0",
+    "@lucide/svelte": "^1.8.0",
     "@sveltejs/kit": "^2.57.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tailwindcss/typography": "^0.5.19",

--- a/src/lib/components/ui/calendar/calendar-caption.svelte
+++ b/src/lib/components/ui/calendar/calendar-caption.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import type { ComponentProps } from 'svelte';
+  import type Calendar from './calendar.svelte';
+  import CalendarMonthSelect from './calendar-month-select.svelte';
+  import CalendarYearSelect from './calendar-year-select.svelte';
+  import { DateFormatter, getLocalTimeZone, type DateValue } from '@internationalized/date';
+
+  let {
+    captionLayout,
+    months,
+    monthFormat,
+    years,
+    yearFormat,
+    month,
+    locale,
+    placeholder = $bindable(),
+    monthIndex = 0,
+  }: {
+    captionLayout: ComponentProps<typeof Calendar>['captionLayout'];
+    months: ComponentProps<typeof CalendarMonthSelect>['months'];
+    monthFormat: ComponentProps<typeof CalendarMonthSelect>['monthFormat'];
+    years: ComponentProps<typeof CalendarYearSelect>['years'];
+    yearFormat: ComponentProps<typeof CalendarYearSelect>['yearFormat'];
+    month: DateValue;
+    placeholder: DateValue | undefined;
+    locale: string;
+    monthIndex: number;
+  } = $props();
+
+  function formatYear(date: DateValue) {
+    const dateObj = date.toDate(getLocalTimeZone());
+    if (typeof yearFormat === 'function') return yearFormat(dateObj.getFullYear());
+    return new DateFormatter(locale, { year: yearFormat }).format(dateObj);
+  }
+
+  function formatMonth(date: DateValue) {
+    const dateObj = date.toDate(getLocalTimeZone());
+    if (typeof monthFormat === 'function') return monthFormat(dateObj.getMonth() + 1);
+    return new DateFormatter(locale, { month: monthFormat }).format(dateObj);
+  }
+</script>
+
+{#snippet MonthSelect()}
+  <CalendarMonthSelect
+    {months}
+    {monthFormat}
+    value={month.month}
+    onchange={(e) => {
+      if (!placeholder) return;
+      const v = Number.parseInt(e.currentTarget.value);
+      const newPlaceholder = placeholder.set({ month: v });
+      placeholder = newPlaceholder.subtract({ months: monthIndex });
+    }}
+  />
+{/snippet}
+
+{#snippet YearSelect()}
+  <CalendarYearSelect {years} {yearFormat} value={month.year} />
+{/snippet}
+
+{#if captionLayout === 'dropdown'}
+  {@render MonthSelect()}
+  {@render YearSelect()}
+{:else if captionLayout === 'dropdown-months'}
+  {@render MonthSelect()}
+  {#if placeholder}
+    {formatYear(placeholder)}
+  {/if}
+{:else if captionLayout === 'dropdown-years'}
+  {#if placeholder}
+    {formatMonth(placeholder)}
+  {/if}
+  {@render YearSelect()}
+{:else}
+  {formatMonth(month)} {formatYear(month)}
+{/if}

--- a/src/lib/components/ui/calendar/calendar-cell.svelte
+++ b/src/lib/components/ui/calendar/calendar-cell.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.CellProps = $props();
+</script>
+
+<CalendarPrimitive.Cell
+  bind:ref
+  class={cn(
+    'relative size-(--cell-size) p-0 text-center text-sm focus-within:z-20 [&:first-child[data-selected]_[data-bits-day]]:rounded-s-(--cell-radius) [&:last-child[data-selected]_[data-bits-day]]:rounded-e-(--cell-radius)',
+    className,
+  )}
+  {...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-day.svelte
+++ b/src/lib/components/ui/calendar/calendar-day.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.DayProps = $props();
+</script>
+
+<CalendarPrimitive.Day
+  bind:ref
+  class={cn(
+    'flex size-(--cell-size) flex-col items-center justify-center gap-1 rounded-(--cell-radius) p-0 leading-none font-normal whitespace-nowrap select-none',
+    '[&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
+    'not-data-selected:hover:bg-accent/50 not-data-selected:hover:text-accent-foreground',
+    '[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground [&[data-today][data-disabled]]:text-muted-foreground',
+    'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:hover:text-foreground',
+    // Outside months
+    '[&[data-outside-month]:not([data-selected])]:text-muted-foreground [&[data-outside-month]:not([data-selected])]:hover:text-accent-foreground',
+    // Disabled
+    'data-[disabled]:pointer-events-none data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',
+    // Unavailable
+    'data-[unavailable]:text-muted-foreground data-[unavailable]:line-through',
+    // focus
+    'focus:relative focus:border-ring focus:ring-ring/50',
+    // inner spans
+    '[&>span]:text-xs [&>span]:opacity-70',
+    className,
+  )}
+  {...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-grid-body.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid-body.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.GridBodyProps = $props();
+</script>
+
+<CalendarPrimitive.GridBody bind:ref class={cn(className)} {...restProps} />

--- a/src/lib/components/ui/calendar/calendar-grid-head.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid-head.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.GridHeadProps = $props();
+</script>
+
+<CalendarPrimitive.GridHead bind:ref class={cn(className)} {...restProps} />

--- a/src/lib/components/ui/calendar/calendar-grid-row.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid-row.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.GridRowProps = $props();
+</script>
+
+<CalendarPrimitive.GridRow bind:ref class={cn('flex', className)} {...restProps} />

--- a/src/lib/components/ui/calendar/calendar-grid.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.GridProps = $props();
+</script>
+
+<CalendarPrimitive.Grid
+  bind:ref
+  class={cn('flex w-full border-collapse flex-col', className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-head-cell.svelte
+++ b/src/lib/components/ui/calendar/calendar-head-cell.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.HeadCellProps = $props();
+</script>
+
+<CalendarPrimitive.HeadCell
+  bind:ref
+  class={cn(
+    'w-(--cell-size) rounded-md text-[0.8rem] font-normal text-muted-foreground',
+    className,
+  )}
+  {...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-header.svelte
+++ b/src/lib/components/ui/calendar/calendar-header.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.HeaderProps = $props();
+</script>
+
+<CalendarPrimitive.Header
+  bind:ref
+  class={cn(
+    'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
+    className,
+  )}
+  {...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-heading.svelte
+++ b/src/lib/components/ui/calendar/calendar-heading.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: CalendarPrimitive.HeadingProps = $props();
+</script>
+
+<CalendarPrimitive.Heading
+  bind:ref
+  class={cn('px-(--cell-size) text-sm font-medium', className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-month-select.svelte
+++ b/src/lib/components/ui/calendar/calendar-month-select.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+  import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    value,
+    onchange,
+    ...restProps
+  }: WithoutChildrenOrChild<CalendarPrimitive.MonthSelectProps> = $props();
+</script>
+
+<span
+  class={cn(
+    'relative flex rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50',
+    className,
+  )}
+>
+  <CalendarPrimitive.MonthSelect
+    bind:ref
+    class="absolute inset-0 bg-background opacity-0 dark:bg-popover dark:text-popover-foreground"
+    {...restProps}
+  >
+    {#snippet child({ props, monthItems, selectedMonthItem })}
+      <select {...props} {value} {onchange}>
+        {#each monthItems as monthItem (monthItem.value)}
+          <option
+            value={monthItem.value}
+            selected={value !== undefined
+              ? monthItem.value === value
+              : monthItem.value === selectedMonthItem.value}
+          >
+            {monthItem.label}
+          </option>
+        {/each}
+      </select>
+      <span
+        class="flex h-(--cell-size) items-center gap-1 rounded-md ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5 [&>svg]:text-muted-foreground"
+        aria-hidden="true"
+      >
+        {monthItems.find((item) => item.value === value)?.label || selectedMonthItem.label}
+        <ChevronDownIcon class={cn('size-4', className)} />
+      </span>
+    {/snippet}
+  </CalendarPrimitive.MonthSelect>
+</span>

--- a/src/lib/components/ui/calendar/calendar-month.svelte
+++ b/src/lib/components/ui/calendar/calendar-month.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { type WithElementRef, cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div {...restProps} bind:this={ref} class={cn('flex w-full flex-col gap-4', className)}>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/calendar/calendar-months.svelte
+++ b/src/lib/components/ui/calendar/calendar-months.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+  import { cn, type WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  class={cn('relative flex flex-col gap-4 md:flex-row', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/calendar/calendar-nav.svelte
+++ b/src/lib/components/ui/calendar/calendar-nav.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { cn, type WithElementRef } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<nav
+  {...restProps}
+  bind:this={ref}
+  class={cn('absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1', className)}
+>
+  {@render children?.()}
+</nav>

--- a/src/lib/components/ui/calendar/calendar-next-button.svelte
+++ b/src/lib/components/ui/calendar/calendar-next-button.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+  import { buttonVariants, type ButtonVariant } from '$lib/components/ui/button/index.js';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    variant = 'ghost',
+    ...restProps
+  }: CalendarPrimitive.NextButtonProps & {
+    variant?: ButtonVariant;
+  } = $props();
+</script>
+
+{#snippet Fallback()}
+  <ChevronRightIcon class={cn('size-4', className)} />
+{/snippet}
+
+<CalendarPrimitive.NextButton
+  bind:ref
+  class={cn(
+    buttonVariants({ variant }),
+    'size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180',
+    className,
+  )}
+  {...restProps}
+>
+  {#if children}
+    {@render children?.()}
+  {:else}
+    {@render Fallback()}
+  {/if}
+</CalendarPrimitive.NextButton>

--- a/src/lib/components/ui/calendar/calendar-prev-button.svelte
+++ b/src/lib/components/ui/calendar/calendar-prev-button.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
+  import { buttonVariants, type ButtonVariant } from '$lib/components/ui/button/index.js';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    variant = 'ghost',
+    ...restProps
+  }: CalendarPrimitive.PrevButtonProps & {
+    variant?: ButtonVariant;
+  } = $props();
+</script>
+
+{#snippet Fallback()}
+  <ChevronLeftIcon class={cn('size-4', className)} />
+{/snippet}
+
+<CalendarPrimitive.PrevButton
+  bind:ref
+  class={cn(
+    buttonVariants({ variant }),
+    'size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180',
+    className,
+  )}
+  {...restProps}
+>
+  {#if children}
+    {@render children?.()}
+  {:else}
+    {@render Fallback()}
+  {/if}
+</CalendarPrimitive.PrevButton>

--- a/src/lib/components/ui/calendar/calendar-year-select.svelte
+++ b/src/lib/components/ui/calendar/calendar-year-select.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+  import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    value,
+    ...restProps
+  }: WithoutChildrenOrChild<CalendarPrimitive.YearSelectProps> = $props();
+</script>
+
+<span
+  class={cn(
+    'relative flex rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50',
+    className,
+  )}
+>
+  <CalendarPrimitive.YearSelect
+    bind:ref
+    class="absolute inset-0 opacity-0 dark:bg-popover dark:text-popover-foreground"
+    {...restProps}
+  >
+    {#snippet child({ props, yearItems, selectedYearItem })}
+      <select {...props} {value}>
+        {#each yearItems as yearItem (yearItem.value)}
+          <option
+            value={yearItem.value}
+            selected={value !== undefined
+              ? yearItem.value === value
+              : yearItem.value === selectedYearItem.value}
+          >
+            {yearItem.label}
+          </option>
+        {/each}
+      </select>
+      <span
+        class="flex h-(--cell-size) items-center gap-1 rounded-md ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5 [&>svg]:text-muted-foreground"
+        aria-hidden="true"
+      >
+        {yearItems.find((item) => item.value === value)?.label || selectedYearItem.label}
+        <ChevronDownIcon class={cn('size-4', className)} />
+      </span>
+    {/snippet}
+  </CalendarPrimitive.YearSelect>
+</span>

--- a/src/lib/components/ui/calendar/calendar.svelte
+++ b/src/lib/components/ui/calendar/calendar.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { Calendar as CalendarPrimitive } from 'bits-ui';
+  import * as Calendar from './index.js';
+  import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+  import type { ButtonVariant } from '../button/button.svelte';
+  import { isEqualMonth, type DateValue } from '@internationalized/date';
+  import type { Snippet } from 'svelte';
+
+  let {
+    ref = $bindable(null),
+    value = $bindable(),
+    placeholder = $bindable(),
+    class: className,
+    weekdayFormat = 'short',
+    buttonVariant = 'ghost',
+    captionLayout = 'label',
+    locale = 'en-US',
+    months: monthsProp,
+    years,
+    monthFormat: monthFormatProp,
+    yearFormat = 'numeric',
+    day,
+    disableDaysOutsideMonth = false,
+    ...restProps
+  }: WithoutChildrenOrChild<CalendarPrimitive.RootProps> & {
+    buttonVariant?: ButtonVariant;
+    captionLayout?: 'dropdown' | 'dropdown-months' | 'dropdown-years' | 'label';
+    months?: CalendarPrimitive.MonthSelectProps['months'];
+    years?: CalendarPrimitive.YearSelectProps['years'];
+    monthFormat?: CalendarPrimitive.MonthSelectProps['monthFormat'];
+    yearFormat?: CalendarPrimitive.YearSelectProps['yearFormat'];
+    day?: Snippet<[{ day: DateValue; outsideMonth: boolean }]>;
+  } = $props();
+
+  const monthFormat = $derived.by(() => {
+    if (monthFormatProp) return monthFormatProp;
+    if (captionLayout.startsWith('dropdown')) return 'short';
+    return 'long';
+  });
+</script>
+
+<!--
+Discriminated Unions + Destructing (required for bindable) do not
+get along, so we shut typescript up by casting `value` to `never`.
+-->
+<CalendarPrimitive.Root
+  bind:value={value as never}
+  bind:ref
+  bind:placeholder
+  {weekdayFormat}
+  {disableDaysOutsideMonth}
+  class={cn(
+    'group/calendar bg-background p-2 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(7)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
+    className,
+  )}
+  {locale}
+  {monthFormat}
+  {yearFormat}
+  {...restProps}
+>
+  {#snippet children({ months, weekdays })}
+    <Calendar.Months>
+      <Calendar.Nav>
+        <Calendar.PrevButton variant={buttonVariant} />
+        <Calendar.NextButton variant={buttonVariant} />
+      </Calendar.Nav>
+      {#each months as month, monthIndex (month)}
+        <Calendar.Month>
+          <Calendar.Header>
+            <Calendar.Caption
+              {captionLayout}
+              months={monthsProp}
+              {monthFormat}
+              {years}
+              {yearFormat}
+              month={month.value}
+              bind:placeholder
+              {locale}
+              {monthIndex}
+            />
+          </Calendar.Header>
+          <Calendar.Grid>
+            <Calendar.GridHead>
+              <Calendar.GridRow class="select-none">
+                {#each weekdays as weekday, i (i)}
+                  <Calendar.HeadCell>
+                    {weekday.slice(0, 2)}
+                  </Calendar.HeadCell>
+                {/each}
+              </Calendar.GridRow>
+            </Calendar.GridHead>
+            <Calendar.GridBody>
+              {#each month.weeks as weekDates (weekDates)}
+                <Calendar.GridRow class="mt-2 w-full">
+                  {#each weekDates as date (date)}
+                    <Calendar.Cell {date} month={month.value}>
+                      {#if day}
+                        {@render day({
+                          day: date,
+                          outsideMonth: !isEqualMonth(date, month.value),
+                        })}
+                      {:else}
+                        <Calendar.Day />
+                      {/if}
+                    </Calendar.Cell>
+                  {/each}
+                </Calendar.GridRow>
+              {/each}
+            </Calendar.GridBody>
+          </Calendar.Grid>
+        </Calendar.Month>
+      {/each}
+    </Calendar.Months>
+  {/snippet}
+</CalendarPrimitive.Root>

--- a/src/lib/components/ui/calendar/index.ts
+++ b/src/lib/components/ui/calendar/index.ts
@@ -1,0 +1,40 @@
+import Root from './calendar.svelte';
+import Cell from './calendar-cell.svelte';
+import Day from './calendar-day.svelte';
+import Grid from './calendar-grid.svelte';
+import Header from './calendar-header.svelte';
+import Months from './calendar-months.svelte';
+import GridRow from './calendar-grid-row.svelte';
+import Heading from './calendar-heading.svelte';
+import GridBody from './calendar-grid-body.svelte';
+import GridHead from './calendar-grid-head.svelte';
+import HeadCell from './calendar-head-cell.svelte';
+import NextButton from './calendar-next-button.svelte';
+import PrevButton from './calendar-prev-button.svelte';
+import MonthSelect from './calendar-month-select.svelte';
+import YearSelect from './calendar-year-select.svelte';
+import Month from './calendar-month.svelte';
+import Nav from './calendar-nav.svelte';
+import Caption from './calendar-caption.svelte';
+
+export {
+  Day,
+  Cell,
+  Grid,
+  Header,
+  Months,
+  GridRow,
+  Heading,
+  GridBody,
+  GridHead,
+  HeadCell,
+  NextButton,
+  PrevButton,
+  Nav,
+  Month,
+  YearSelect,
+  MonthSelect,
+  Caption,
+  //
+  Root as Calendar,
+};

--- a/src/lib/components/ui/popover/index.ts
+++ b/src/lib/components/ui/popover/index.ts
@@ -1,0 +1,28 @@
+import Root from './popover.svelte';
+import Close from './popover-close.svelte';
+import Content from './popover-content.svelte';
+import Description from './popover-description.svelte';
+import Header from './popover-header.svelte';
+import Title from './popover-title.svelte';
+import Trigger from './popover-trigger.svelte';
+import Portal from './popover-portal.svelte';
+
+export {
+  Root,
+  Content,
+  Description,
+  Header,
+  Title,
+  Trigger,
+  Close,
+  Portal,
+  //
+  Root as Popover,
+  Content as PopoverContent,
+  Description as PopoverDescription,
+  Header as PopoverHeader,
+  Title as PopoverTitle,
+  Trigger as PopoverTrigger,
+  Close as PopoverClose,
+  Portal as PopoverPortal,
+};

--- a/src/lib/components/ui/popover/popover-close.svelte
+++ b/src/lib/components/ui/popover/popover-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Popover as PopoverPrimitive } from 'bits-ui';
+
+  let { ref = $bindable(null), ...restProps }: PopoverPrimitive.CloseProps = $props();
+</script>
+
+<PopoverPrimitive.Close bind:ref data-slot="popover-close" {...restProps} />

--- a/src/lib/components/ui/popover/popover-content.svelte
+++ b/src/lib/components/ui/popover/popover-content.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { Popover as PopoverPrimitive } from 'bits-ui';
+  import PopoverPortal from './popover-portal.svelte';
+  import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+  import type { ComponentProps } from 'svelte';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    sideOffset = 4,
+    align = 'center',
+    portalProps,
+    ...restProps
+  }: PopoverPrimitive.ContentProps & {
+    portalProps?: WithoutChildrenOrChild<ComponentProps<typeof PopoverPortal>>;
+  } = $props();
+</script>
+
+<PopoverPortal {...portalProps}>
+  <PopoverPrimitive.Content
+    bind:ref
+    data-slot="popover-content"
+    {sideOffset}
+    {align}
+    class={cn(
+      'z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+      className,
+    )}
+    {...restProps}
+  />
+</PopoverPortal>

--- a/src/lib/components/ui/popover/popover-description.svelte
+++ b/src/lib/components/ui/popover/popover-description.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+  import { cn, type WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="popover-description"
+  class={cn('text-muted-foreground', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/popover/popover-header.svelte
+++ b/src/lib/components/ui/popover/popover-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+  import { cn, type WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="popover-header"
+  class={cn('flex flex-col gap-0.5 text-sm', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/popover/popover-portal.svelte
+++ b/src/lib/components/ui/popover/popover-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Popover as PopoverPrimitive } from 'bits-ui';
+
+  let { ...restProps }: PopoverPrimitive.PortalProps = $props();
+</script>
+
+<PopoverPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/popover/popover-title.svelte
+++ b/src/lib/components/ui/popover/popover-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+  import { cn, type WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="popover-title"
+  class={cn('font-heading font-medium', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/popover/popover-trigger.svelte
+++ b/src/lib/components/ui/popover/popover-trigger.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import { Popover as PopoverPrimitive } from 'bits-ui';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: PopoverPrimitive.TriggerProps = $props();
+</script>
+
+<PopoverPrimitive.Trigger
+  bind:ref
+  data-slot="popover-trigger"
+  class={cn('', className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/popover/popover.svelte
+++ b/src/lib/components/ui/popover/popover.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Popover as PopoverPrimitive } from 'bits-ui';
+
+  let { open = $bindable(false), ...restProps }: PopoverPrimitive.RootProps = $props();
+</script>
+
+<PopoverPrimitive.Root bind:open {...restProps} />

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -63,6 +63,7 @@ export const seatSections = pgTable(
       .notNull()
       .references(() => events.id),
     name: varchar('name', { length: 50 }).notNull(),
+    prefix: varchar('prefix', { length: 10 }).notNull(),
     rows: integer('rows').notNull(),
     cols: integer('cols').notNull(),
     price: decimal('price', { precision: 12, scale: 2 }).notNull(),
@@ -87,6 +88,7 @@ export const seats = pgTable(
     eventId: integer('event_id')
       .notNull()
       .references(() => events.id),
+    prefix: varchar('prefix', { length: 10 }).notNull(),
     rowLabel: varchar('row_label', { length: 5 }).notNull(),
     colNumber: integer('col_number').notNull(),
     status: seatStatusEnum('status').notNull().default('available'),
@@ -94,7 +96,12 @@ export const seats = pgTable(
     lockedAt: timestamp('locked_at', { withTimezone: true }),
   },
   (table) => [
-    uniqueIndex('uq_seat_label_per_event').on(table.eventId, table.rowLabel, table.colNumber),
+    uniqueIndex('uq_seat_label_per_event').on(
+      table.eventId,
+      table.prefix,
+      table.rowLabel,
+      table.colNumber,
+    ),
     index('idx_seats_event_status').on(table.eventId, table.status),
     index('idx_seats_section').on(table.sectionId),
   ],

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -31,6 +31,7 @@ function getRowLabel(index: number): string {
 
 interface SectionSeed {
   name: string;
+  prefix: string;
   rows: number;
   cols: number;
   price: string;
@@ -136,6 +137,7 @@ export async function seed() {
   await createSections(event1.id, [
     {
       name: 'VIP - Trái',
+      prefix: 'VIPL',
       rows: 3,
       cols: 5,
       price: '2000000',
@@ -147,6 +149,7 @@ export async function seed() {
     },
     {
       name: 'VIP - Phải',
+      prefix: 'VIPR',
       rows: 3,
       cols: 5,
       price: '2000000',
@@ -158,6 +161,7 @@ export async function seed() {
     },
     {
       name: 'Standard',
+      prefix: 'STD',
       rows: 10,
       cols: 20,
       price: '500000',
@@ -199,6 +203,7 @@ export async function seed() {
   await createSections(event2.id, [
     {
       name: 'Diamond',
+      prefix: 'DIA',
       rows: 3,
       cols: 15,
       price: '3000000',
@@ -207,10 +212,11 @@ export async function seed() {
       startRowIndex: 0, // A
       startColIndex: 1,
       sortOrder: 0,
-      disabledSeats: ['B8', 'C8'], // Cột chắn tầm nhìn
+      disabledSeats: ['DIA-B8', 'DIA-C8'], // Cột chắn tầm nhìn
     },
     {
       name: 'Gold',
+      prefix: 'GOLD',
       rows: 5,
       cols: 20,
       price: '1500000',
@@ -222,6 +228,7 @@ export async function seed() {
     },
     {
       name: 'Silver',
+      prefix: 'SIL',
       rows: 10,
       cols: 25,
       price: '700000',
@@ -230,7 +237,7 @@ export async function seed() {
       startRowIndex: 8, // I (nối tiếp Gold)
       startColIndex: 1,
       sortOrder: 2,
-      disabledSeats: ['I13', 'J13', 'K13'], // Cột chắn giữa Silver
+      disabledSeats: ['SIL-I13', 'SIL-J13', 'SIL-K13'], // Cột chắn giữa Silver
     },
   ]);
 
@@ -263,6 +270,7 @@ async function createSections(eventId: number, sections: SectionSeed[]) {
       .values({
         eventId,
         name: s.name,
+        prefix: s.prefix,
         rows: s.rows,
         cols: s.cols,
         price: s.price,
@@ -283,11 +291,12 @@ async function createSections(eventId: number, sections: SectionSeed[]) {
 
       for (let c = 0; c < s.cols; c++) {
         const colNumber = s.startColIndex + c;
-        const label = `${rowLabel}${colNumber}`;
+        const label = `${s.prefix}-${rowLabel}${colNumber}`;
 
         seatValues.push({
           sectionId: section.id,
           eventId,
+          prefix: s.prefix,
           rowLabel,
           colNumber,
           status: disabledSet.has(label) ? ('disabled' as const) : ('available' as const),

--- a/src/lib/server/services/event.service.ts
+++ b/src/lib/server/services/event.service.ts
@@ -22,6 +22,7 @@ async function generateAndInsertSeats(
   sectionId: number,
   section: SectionInput,
 ) {
+  const prefix = section.prefix;
   const startRow = section.start_row_index ?? 0;
   const startCol = section.start_col_index ?? 1;
   const disabledSet = new Set(section.disabled_seats ?? []);
@@ -33,7 +34,7 @@ async function generateAndInsertSeats(
     const rowLabel = getRowLabel(startRow + r);
     for (let c = 0; c < section.cols; c++) {
       const colNumber = startCol + c;
-      const seatKey = `${rowLabel}${colNumber}`;
+      const seatKey = `${prefix}-${rowLabel}${colNumber}`;
       const status: InferInsertModel<typeof seats>['status'] = disabledSet.has(seatKey)
         ? 'disabled'
         : 'available';
@@ -43,6 +44,7 @@ async function generateAndInsertSeats(
       seatsToInsert.push({
         eventId,
         sectionId,
+        prefix,
         rowLabel,
         colNumber,
         status,
@@ -75,6 +77,7 @@ async function insertSectionsWithSeats(
       .values({
         eventId,
         name: sec.name,
+        prefix: sec.prefix,
         rows: sec.rows,
         cols: sec.cols,
         price: String(sec.price),
@@ -245,6 +248,7 @@ export const eventService = {
         return {
           id: s.id,
           name: s.name,
+          prefix: s.prefix,
           price: Number(s.price),
           rows: s.rows,
           cols: s.cols,

--- a/src/lib/server/validators/disabled-seats.validator.ts
+++ b/src/lib/server/validators/disabled-seats.validator.ts
@@ -21,6 +21,12 @@ export function validateDisabledSeats(sections: SectionInput[]): void {
         continue;
       }
 
+      // Check prefix matches the section's prefix
+      if (parsed.prefix !== section.prefix) {
+        invalid.push(label);
+        continue;
+      }
+
       const rowIndex = rowLabelToIndex(parsed.rowLabel);
       if (
         rowIndex < startRow ||

--- a/src/lib/server/validators/seat-overlap.validator.ts
+++ b/src/lib/server/validators/seat-overlap.validator.ts
@@ -24,7 +24,7 @@ export function validateEventRequirements(sections: SectionInput[]): void {
     for (let r = 0; r < section.rows; r++) {
       const rowLabel = getRowLabel(startRow + r);
       for (let c = 0; c < section.cols; c++) {
-        const key = `${rowLabel}${startCol + c}`;
+        const key = `${section.prefix}-${rowLabel}${startCol + c}`;
         if (seatSet.has(key)) conflicts.push(key);
         else seatSet.add(key);
       }

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -7,11 +7,18 @@ const req = (msg: string) => ({
   error: (issue: { input: unknown }) => (issue.input === undefined ? msg : undefined),
 });
 
-const seatLabelRegex = /^[A-Z]+\d+$/; // A1, B12, AA3...
+const seatLabelRegex = /^[A-Z0-9]+-[A-Z]+[1-9]\d*$/; // VIP-A1, STD-B12, V1-AA3...
+const prefixRegex = /^[A-Z0-9]+$/; // Only uppercase letters and digits, no hyphens
 
 // ── Section Schema ─────────────────────────────
 const baseSectionSchema = z.object({
   name: z.string(req('Tên khu vực là bắt buộc')).min(1, 'Tên khu vực không được trống'),
+
+  prefix: z
+    .string(req('Mã tiền tố là bắt buộc'))
+    .min(1, 'Mã tiền tố không được trống')
+    .max(10, 'Mã tiền tố tối đa 10 ký tự')
+    .regex(prefixRegex, 'Mã tiền tố chỉ được chứa chữ in hoa và số (A-Z, 0-9)'),
 
   rows: z
     .number(req('Số hàng là bắt buộc'))
@@ -34,13 +41,13 @@ const baseSectionSchema = z.object({
   start_col_index: z.number().int().min(1, 'start_col_index phải >= 1').default(1),
 
   disabled_seats: z
-    .array(z.string().regex(seatLabelRegex, 'Seat label phải có dạng A1, B12, AA3...'))
+    .array(z.string().regex(seatLabelRegex, 'Seat label phải có dạng VIP-A1, STD-B12...'))
     .default([]),
 
   sort_order: z.number().int().min(0).default(0),
 });
 
-// Thêm cross-field validation: disabled_seats phải nằm trong phạm vi section
+// Thêm cross-field validation: disabled_seats phải nằm trong phạm vi section và có đúng prefix
 const sectionSchema = baseSectionSchema.superRefine((section, ctx) => {
   if (!section.disabled_seats || section.disabled_seats.length === 0) return;
 
@@ -54,12 +61,19 @@ const sectionSchema = baseSectionSchema.superRefine((section, ctx) => {
   const maxRowLabel = getRowLabel(endRow);
 
   const invalidSeats: string[] = [];
+  const wrongPrefix: string[] = [];
 
   for (const label of section.disabled_seats) {
     const parsed = parseSeatLabel(label);
 
     if (!parsed) {
       invalidSeats.push(label);
+      continue;
+    }
+
+    // Check prefix matches the section's prefix
+    if (parsed.prefix !== section.prefix) {
+      wrongPrefix.push(label);
       continue;
     }
 
@@ -73,6 +87,16 @@ const sectionSchema = baseSectionSchema.superRefine((section, ctx) => {
     ) {
       invalidSeats.push(label);
     }
+  }
+
+  if (wrongPrefix.length > 0) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['disabled_seats'],
+      message:
+        `Các ghế có prefix không khớp với khu vực "${section.prefix}": ` +
+        `${wrongPrefix.join(', ')}`,
+    });
   }
 
   if (invalidSeats.length > 0) {

--- a/src/lib/utils/seat-label.test.ts
+++ b/src/lib/utils/seat-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { getRowLabel, rowLabelToIndex, parseSeatLabel } from './seat-label';
+import { getRowLabel, rowLabelToIndex, parseSeatLabel, buildSeatLabel } from './seat-label';
 
 describe('seat-label utils', () => {
   describe('getRowLabel', () => {
@@ -31,18 +31,31 @@ describe('seat-label utils', () => {
   });
 
   describe('parseSeatLabel', () => {
-    it('parses valid seat labels', () => {
-      expect(parseSeatLabel('A1')).toEqual({ rowLabel: 'A', colNumber: 1 });
-      expect(parseSeatLabel('C10')).toEqual({ rowLabel: 'C', colNumber: 10 });
-      expect(parseSeatLabel('AA25')).toEqual({ rowLabel: 'AA', colNumber: 25 });
+    it('parses valid seat labels with prefix', () => {
+      expect(parseSeatLabel('VIP-A1')).toEqual({ prefix: 'VIP', rowLabel: 'A', colNumber: 1 });
+      expect(parseSeatLabel('STD-C10')).toEqual({ prefix: 'STD', rowLabel: 'C', colNumber: 10 });
+      expect(parseSeatLabel('V1-AA25')).toEqual({ prefix: 'V1', rowLabel: 'AA', colNumber: 25 });
+      expect(parseSeatLabel('DIA-B8')).toEqual({ prefix: 'DIA', rowLabel: 'B', colNumber: 8 });
     });
 
     it('returns null for invalid seat labels', () => {
+      expect(parseSeatLabel('A1')).toBeNull(); // missing prefix
       expect(parseSeatLabel('1A')).toBeNull();
       expect(parseSeatLabel('ABC')).toBeNull();
       expect(parseSeatLabel('123')).toBeNull();
-      expect(parseSeatLabel('A-1')).toBeNull();
+      expect(parseSeatLabel('-A1')).toBeNull(); // empty prefix
+      expect(parseSeatLabel('VIP-')).toBeNull(); // no row/col
+      expect(parseSeatLabel('vip-A1')).toBeNull(); // lowercase prefix
+      expect(parseSeatLabel('V-1-A1')).toBeNull(); // hyphen in prefix
       expect(parseSeatLabel('')).toBeNull();
+    });
+  });
+
+  describe('buildSeatLabel', () => {
+    it('builds a full seat label from parts', () => {
+      expect(buildSeatLabel('VIP', 'A', 1)).toBe('VIP-A1');
+      expect(buildSeatLabel('STD', 'C', 10)).toBe('STD-C10');
+      expect(buildSeatLabel('V1', 'AA', 25)).toBe('V1-AA25');
     });
   });
 });

--- a/src/lib/utils/seat-label.ts
+++ b/src/lib/utils/seat-label.ts
@@ -27,10 +27,20 @@ export function rowLabelToIndex(label: string): number {
 }
 
 /**
- * Parse "C5" → { rowLabel: "C", colNumber: 5 }
+ * Parse "VIP-C5" → { prefix: "VIP", rowLabel: "C", colNumber: 5 }
  */
-export function parseSeatLabel(label: string): { rowLabel: string; colNumber: number } | null {
-  const match = label.match(/^([A-Z]+)([1-9]\d*)$/);
+export function parseSeatLabel(
+  label: string,
+): { prefix: string; rowLabel: string; colNumber: number } | null {
+  const match = label.match(/^([A-Z0-9]+)-([A-Z]+)([1-9]\d*)$/);
   if (!match) return null;
-  return { rowLabel: match[1], colNumber: parseInt(match[2], 10) };
+  return { prefix: match[1], rowLabel: match[2], colNumber: parseInt(match[3], 10) };
+}
+
+/**
+ * Build a full seat label from its parts.
+ * ("VIP", "A", 1) → "VIP-A1"
+ */
+export function buildSeatLabel(prefix: string, rowLabel: string, colNumber: number): string {
+  return `${prefix}-${rowLabel}${colNumber}`;
 }


### PR DESCRIPTION
## Mô tả

Khi phân vùng/khu ghế ngồi, có thể sẽ có ghế bị trùng ID/label/tên, có thể dẫn đến hiểu lầm. Nên giải pháp là thêm prefix trước chỗ ngồi để đảm bảo không bị trùng tên.

Closes #49 

## Loại thay đổi

- [x] ✨ Feature mới
- [x] ♻️ Refactor

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)
