### PR TITLE
feat(ui): admin view for event list and event detail

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "my-app",
       "dependencies": {
+        "@tanstack/table-core": "^9.0.0-alpha.32",
         "amqplib": "^1.0.3",
         "argon2": "^0.44.0",
         "drizzle-orm": "^0.45.2",
@@ -27,7 +28,6 @@
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
-        "@tanstack/table-core": "^9.0.0-alpha.32",
         "@types/amqplib": "^0.10.8",
         "@types/node": "^25.6.0",
         "@types/pg": "^8.20.0",

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
+        "@tanstack/table-core": "^9.0.0-alpha.32",
         "@types/amqplib": "^0.10.8",
         "@types/node": "^25.6.0",
         "@types/pg": "^8.20.0",
@@ -279,6 +280,10 @@
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
+
+    "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@9.0.0-alpha.32", "", { "dependencies": { "@tanstack/store": "^0.9.3" } }, "sha512-Ah2PomRoRjrV7f3zQDUJ5Cp6oy5yxTpLGJkpS3dSOyFN7ldAQUeY0BUTCo8mY2OOrkHIjKmlIoDRH12LFv99vw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/table-core": "^9.0.0-alpha.32",
     "@types/amqplib": "^0.10.8",
     "@types/node": "^25.6.0",
     "@types/pg": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/table-core": "^9.0.0-alpha.32",
     "@types/amqplib": "^0.10.8",
     "@types/node": "^25.6.0",
     "@types/pg": "^8.20.0",
@@ -58,6 +57,7 @@
     "vite": "^8.0.8"
   },
   "dependencies": {
+    "@tanstack/table-core": "^9.0.0-alpha.32",
     "amqplib": "^1.0.3",
     "argon2": "^0.44.0",
     "drizzle-orm": "^0.45.2",

--- a/src/lib/components/admin/event/SectionBuilder.svelte
+++ b/src/lib/components/admin/event/SectionBuilder.svelte
@@ -271,13 +271,14 @@
 
     const overlapCount = labelOverlapCount + visualOverlapCount;
 
-    // Row labels for display
-    const rowLabels: string[] = [];
+    // Row labels for display — use numeric grid Y coordinates (not letters)
+    // because different sections at the same layoutY can have different startRowIndex
+    const rowLabels: number[] = [];
     for (let r = 0; r < displayRows; r++) {
-      rowLabels.push(getRowLabel(minRow + r));
+      rowLabels.push(minRow + r);
     }
 
-    // Col labels for display
+    // Col labels for display — use numeric grid X coordinates
     const colLabels: number[] = [];
     for (let c = 0; c < displayCols; c++) {
       colLabels.push(minCol + c);
@@ -366,7 +367,7 @@
           </div>
 
           <!-- Rows -->
-          {#each gridData.grid as row, r (gridData.rowLabels[r])}
+          {#each gridData.grid as row, r (`row-${r}`)}
             <div class="flex items-center gap-px">
               <span class="w-7 shrink-0 pr-1 text-right font-mono text-[9px] text-muted-foreground">
                 {gridData.rowLabels[r]}

--- a/src/lib/components/admin/event/SectionItem.svelte
+++ b/src/lib/components/admin/event/SectionItem.svelte
@@ -21,6 +21,26 @@
 
   let rootEl = $state<HTMLDivElement>();
 
+  // ── Auto-sync layout_y → start_row_index ──
+  // When Admin changes layout_y, automatically update start_row_index to match,
+  // unless Admin has manually edited start_row_index independently.
+  let previousLayoutY = $state(section.layout_y);
+  let previousLayoutX = $state(section.layout_x);
+
+  $effect(() => {
+    if (section.layout_y !== previousLayoutY) {
+      section.start_row_index = section.layout_y;
+      previousLayoutY = section.layout_y;
+    }
+  });
+
+  $effect(() => {
+    if (section.layout_x !== previousLayoutX) {
+      section.start_col_index = section.layout_x === 0 ? 1 : section.layout_x;
+      previousLayoutX = section.layout_x;
+    }
+  });
+
   /** Dispatch a bubbling 'remove' CustomEvent AND call the onremove callback if provided */
   function handleRemove() {
     // Dispatch DOM event for event-based listeners (e.g. parent using onremove on the element)

--- a/src/lib/components/admin/event/SectionItem.svelte
+++ b/src/lib/components/admin/event/SectionItem.svelte
@@ -26,16 +26,18 @@
   // unless Admin has manually edited start_row_index independently.
   let previousLayoutY = $state(section.layout_y);
   let previousLayoutX = $state(section.layout_x);
+  let startRowEdited = $state(false);
+  let startColEdited = $state(false);
 
   $effect(() => {
-    if (section.layout_y !== previousLayoutY) {
+    if (section.layout_y !== previousLayoutY && !startRowEdited) {
       section.start_row_index = section.layout_y;
       previousLayoutY = section.layout_y;
     }
   });
 
   $effect(() => {
-    if (section.layout_x !== previousLayoutX) {
+    if (section.layout_x !== previousLayoutX && !startColEdited) {
       section.start_col_index = section.layout_x === 0 ? 1 : section.layout_x;
       previousLayoutX = section.layout_x;
     }
@@ -233,6 +235,7 @@
               type="number"
               min="0"
               bind:value={section.start_row_index}
+              oninput={() => (startRowEdited = true)}
             />
             {#if fieldError('start_row_index')}
               <span class="text-xs text-destructive">{fieldError('start_row_index')}</span>
@@ -248,6 +251,7 @@
               type="number"
               min="1"
               bind:value={section.start_col_index}
+              oninput={() => (startColEdited = true)}
             />
             {#if fieldError('start_col_index')}
               <span class="text-xs text-destructive">{fieldError('start_col_index')}</span>

--- a/src/lib/components/admin/event/SectionItem.svelte
+++ b/src/lib/components/admin/event/SectionItem.svelte
@@ -24,9 +24,7 @@
   /** Dispatch a bubbling 'remove' CustomEvent AND call the onremove callback if provided */
   function handleRemove() {
     // Dispatch DOM event for event-based listeners (e.g. parent using onremove on the element)
-    rootEl?.dispatchEvent(
-      new CustomEvent('remove', { bubbles: true, detail: { index } }),
-    );
+    rootEl?.dispatchEvent(new CustomEvent('remove', { bubbles: true, detail: { index } }));
     // Also invoke callback prop for direct prop-based usage
     onremove?.();
   }

--- a/src/lib/components/ui/data-table/data-table.svelte.ts
+++ b/src/lib/components/ui/data-table/data-table.svelte.ts
@@ -1,0 +1,142 @@
+import {
+  type RowData,
+  type TableOptions,
+  type TableOptionsResolved,
+  type TableState,
+  type Updater,
+  createTable,
+} from '@tanstack/table-core';
+
+/**
+ * Creates a reactive TanStack table object for Svelte.
+ * @param options Table options to create the table with.
+ * @returns A reactive table object.
+ * @example
+ * ```svelte
+ * <script>
+ *   const table = createSvelteTable({ ... })
+ * </script>
+ *
+ * <table>
+ *   <thead>
+ *     {#each table.getHeaderGroups() as headerGroup}
+ *       <tr>
+ *         {#each headerGroup.headers as header}
+ *           <th colspan={header.colSpan}>
+ *         	   <FlexRender content={header.column.columnDef.header} context={header.getContext()} />
+ *         	 </th>
+ *         {/each}
+ *       </tr>
+ *     {/each}
+ *   </thead>
+ * 	 <!-- ... -->
+ * </table>
+ * ```
+ */
+export function createSvelteTable<TData extends RowData>(options: TableOptions<TData>) {
+  const resolvedOptions: TableOptionsResolved<TData> = mergeObjects(
+    {
+      state: {},
+      onStateChange() {},
+      renderFallbackValue: null,
+      mergeOptions: (
+        defaultOptions: TableOptions<TData>,
+        options: Partial<TableOptions<TData>>,
+      ) => {
+        return mergeObjects(defaultOptions, options);
+      },
+    },
+    options,
+  );
+
+  const table = createTable(resolvedOptions);
+  let state = $state<TableState>(table.initialState);
+
+  function updateOptions() {
+    table.setOptions(() => {
+      return mergeObjects(resolvedOptions, options, {
+        state: mergeObjects(state, options.state || {}),
+
+        onStateChange: (updater: Updater<TableState>) => {
+          if (updater instanceof Function) state = updater(state);
+          else state = mergeObjects(state, updater);
+
+          options.onStateChange?.(updater);
+        },
+      });
+    });
+  }
+
+  updateOptions();
+
+  $effect.pre(() => {
+    updateOptions();
+  });
+
+  return table;
+}
+
+type MaybeThunk<T extends object> = T | (() => T | null | undefined);
+type Intersection<T extends readonly unknown[]> = (T extends [infer H, ...infer R]
+  ? H & Intersection<R>
+  : unknown) & {};
+
+/**
+ * Lazily merges several objects (or thunks) while preserving
+ * getter semantics from every source.
+ *
+ * Proxy-based to avoid known WebKit recursion issue.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function mergeObjects<Sources extends readonly MaybeThunk<any>[]>(
+  ...sources: Sources
+): Intersection<{ [K in keyof Sources]: Sources[K] }> {
+  const resolve = <T extends object>(src: MaybeThunk<T>): T | undefined =>
+    typeof src === 'function' ? (src() ?? undefined) : src;
+
+  const findSourceWithKey = (key: PropertyKey) => {
+    for (let i = sources.length - 1; i >= 0; i--) {
+      const obj = resolve(sources[i]);
+      if (obj && key in obj) return obj;
+    }
+    return undefined;
+  };
+
+  return new Proxy(Object.create(null), {
+    get(_, key) {
+      const src = findSourceWithKey(key);
+
+      return src?.[key as never];
+    },
+
+    has(_, key) {
+      return !!findSourceWithKey(key);
+    },
+
+    ownKeys(): (string | symbol)[] {
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      const all = new Set<string | symbol>();
+      for (const s of sources) {
+        const obj = resolve(s);
+        if (obj) {
+          for (const k of Reflect.ownKeys(obj) as (string | symbol)[]) {
+            all.add(k);
+          }
+        }
+      }
+      return [...all];
+    },
+
+    getOwnPropertyDescriptor(_, key) {
+      const src = findSourceWithKey(key);
+      if (!src) return undefined;
+      return {
+        configurable: true,
+        enumerable: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value: (src as any)[key],
+        writable: true,
+      };
+    },
+  }) as Intersection<{ [K in keyof Sources]: Sources[K] }>;
+}

--- a/src/lib/components/ui/data-table/data-table.svelte.ts
+++ b/src/lib/components/ui/data-table/data-table.svelte.ts
@@ -9,12 +9,12 @@ import {
 
 /**
  * Creates a reactive TanStack table object for Svelte.
- * @param options Table options to create the table with.
+ * @param options Table options to create the table with (or a function that returns options).
  * @returns A reactive table object.
  * @example
  * ```svelte
  * <script>
- *   const table = createSvelteTable({ ... })
+ *   const table = createSvelteTable(() => ({ ... }))
  * </script>
  *
  * <table>
@@ -33,7 +33,12 @@ import {
  * </table>
  * ```
  */
-export function createSvelteTable<TData extends RowData>(options: TableOptions<TData>) {
+export function createSvelteTable<TData extends RowData>(
+  options: TableOptions<TData> | (() => TableOptions<TData>),
+) {
+  const getOptions = typeof options === 'function' ? options : () => options;
+
+  const initialOptions = getOptions();
   const resolvedOptions: TableOptionsResolved<TData> = mergeObjects(
     {
       state: {},
@@ -46,22 +51,23 @@ export function createSvelteTable<TData extends RowData>(options: TableOptions<T
         return mergeObjects(defaultOptions, options);
       },
     },
-    options,
+    initialOptions,
   );
 
   const table = createTable(resolvedOptions);
   let state = $state<TableState>(table.initialState);
 
   function updateOptions() {
+    const currentOptions = getOptions();
     table.setOptions(() => {
-      return mergeObjects(resolvedOptions, options, {
-        state: mergeObjects(state, options.state || {}),
+      return mergeObjects(resolvedOptions, currentOptions, {
+        state: mergeObjects(state, currentOptions.state || {}),
 
         onStateChange: (updater: Updater<TableState>) => {
           if (updater instanceof Function) state = updater(state);
-          else state = mergeObjects(state, updater);
+          else state = updater as TableState;
 
-          options.onStateChange?.(updater);
+          currentOptions.onStateChange?.(updater);
         },
       });
     });

--- a/src/lib/components/ui/data-table/flex-render.svelte
+++ b/src/lib/components/ui/data-table/flex-render.svelte
@@ -1,0 +1,40 @@
+<script
+  lang="ts"
+  generics="TData, TValue, TContext extends HeaderContext<TData, TValue> | CellContext<TData, TValue>"
+>
+  import type { CellContext, ColumnDefTemplate, HeaderContext } from '@tanstack/table-core';
+  import { RenderComponentConfig, RenderSnippetConfig } from './render-helpers.js';
+  import type { Attachment } from 'svelte/attachments';
+  type Props = {
+    /** The cell or header field of the current cell's column definition. */
+    content?: TContext extends HeaderContext<TData, TValue>
+      ? ColumnDefTemplate<HeaderContext<TData, TValue>>
+      : TContext extends CellContext<TData, TValue>
+        ? ColumnDefTemplate<CellContext<TData, TValue>>
+        : never;
+    /** The result of the `getContext()` function of the header or cell */
+    context: TContext;
+
+    /** Used to pass attachments that can't be gotten through context */
+    attach?: Attachment;
+  };
+
+  let { content, context, attach }: Props = $props();
+</script>
+
+{#if typeof content === 'string'}
+  {content}
+{:else if content instanceof Function}
+  <!-- It's unlikely that a CellContext will be passed to a Header -->
+  <!-- eslint-disable-next-line @typescript-eslint/no-explicit-any -->
+  {@const result = content(context as any)}
+  {#if result instanceof RenderComponentConfig}
+    {@const { component: Component, props } = result}
+    <Component {...props} {attach} />
+  {:else if result instanceof RenderSnippetConfig}
+    {@const { snippet, params } = result}
+    {@render snippet({ ...params, attach })}
+  {:else}
+    {result}
+  {/if}
+{/if}

--- a/src/lib/components/ui/data-table/index.ts
+++ b/src/lib/components/ui/data-table/index.ts
@@ -1,0 +1,3 @@
+export { default as FlexRender } from './flex-render.svelte';
+export { renderComponent, renderSnippet } from './render-helpers.js';
+export { createSvelteTable } from './data-table.svelte.js';

--- a/src/lib/components/ui/data-table/render-helpers.ts
+++ b/src/lib/components/ui/data-table/render-helpers.ts
@@ -1,0 +1,111 @@
+import type { Component, ComponentProps, Snippet } from 'svelte';
+
+/**
+ * A helper class to make it easy to identify Svelte components in
+ * `columnDef.cell` and `columnDef.header` properties.
+ *
+ * > NOTE: This class should only be used internally by the adapter. If you're
+ * reading this and you don't know what this is for, you probably don't need it.
+ *
+ * @example
+ * ```svelte
+ * {@const result = content(context as any)}
+ * {#if result instanceof RenderComponentConfig}
+ *   {@const { component: Component, props } = result}
+ *   <Component {...props} />
+ * {/if}
+ * ```
+ */
+export class RenderComponentConfig<TComponent extends Component> {
+  component: TComponent;
+  props: ComponentProps<TComponent> | Record<string, never>;
+  constructor(
+    component: TComponent,
+    props: ComponentProps<TComponent> | Record<string, never> = {},
+  ) {
+    this.component = component;
+    this.props = props;
+  }
+}
+
+/**
+ * A helper class to make it easy to identify Svelte Snippets in `columnDef.cell` and `columnDef.header` properties.
+ *
+ * > NOTE: This class should only be used internally by the adapter. If you're
+ * reading this and you don't know what this is for, you probably don't need it.
+ *
+ * @example
+ * ```svelte
+ * {@const result = content(context as any)}
+ * {#if result instanceof RenderSnippetConfig}
+ *   {@const { snippet, params } = result}
+ *   {@render snippet(params)}
+ * {/if}
+ * ```
+ */
+export class RenderSnippetConfig<TProps> {
+  snippet: Snippet<[TProps]>;
+  params: TProps;
+  constructor(snippet: Snippet<[TProps]>, params: TProps) {
+    this.snippet = snippet;
+    this.params = params;
+  }
+}
+
+/**
+ * A helper function to help create cells from Svelte components through ColumnDef's `cell` and `header` properties.
+ *
+ * This is only to be used with Svelte Components - use `renderSnippet` for Svelte Snippets.
+ *
+ * @param component A Svelte component
+ * @param props The props to pass to `component`
+ * @returns A `RenderComponentConfig` object that helps svelte-table know how to render the header/cell component.
+ * @example
+ * ```ts
+ * // +page.svelte
+ * const defaultColumns = [
+ *   columnHelper.accessor('name', {
+ *     header: header => renderComponent(SortHeader, { label: 'Name', header }),
+ *   }),
+ *   columnHelper.accessor('state', {
+ *     header: header => renderComponent(SortHeader, { label: 'State', header }),
+ *   }),
+ * ]
+ * ```
+ * @see {@link https://tanstack.com/table/latest/docs/guide/column-defs}
+ */
+export function renderComponent<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends Component<any>,
+  Props extends ComponentProps<T>,
+>(component: T, props: Props = {} as Props) {
+  return new RenderComponentConfig(component, props);
+}
+
+/**
+ * A helper function to help create cells from Svelte Snippets through ColumnDef's `cell` and `header` properties.
+ *
+ * The snippet must only take one parameter.
+ *
+ * This is only to be used with Snippets - use `renderComponent` for Svelte Components.
+ *
+ * @param snippet
+ * @param params
+ * @returns - A `RenderSnippetConfig` object that helps svelte-table know how to render the header/cell snippet.
+ * @example
+ * ```ts
+ * // +page.svelte
+ * const defaultColumns = [
+ *   columnHelper.accessor('name', {
+ *     cell: cell => renderSnippet(nameSnippet, { name: cell.row.name }),
+ *   }),
+ *   columnHelper.accessor('state', {
+ *     cell: cell => renderSnippet(stateSnippet, { state: cell.row.state }),
+ *   }),
+ * ]
+ * ```
+ * @see {@link https://tanstack.com/table/latest/docs/guide/column-defs}
+ */
+export function renderSnippet<TProps>(snippet: Snippet<[TProps]>, params: TProps = {} as TProps) {
+  return new RenderSnippetConfig(snippet, params);
+}

--- a/src/lib/components/ui/data-table/render-helpers.ts
+++ b/src/lib/components/ui/data-table/render-helpers.ts
@@ -21,7 +21,7 @@ export class RenderComponentConfig<TComponent extends Component> {
   props: ComponentProps<TComponent> | Record<string, never>;
   constructor(
     component: TComponent,
-    props: ComponentProps<TComponent> | Record<string, never> = {},
+    props: ComponentProps<TComponent> | Record<string, never>,
   ) {
     this.component = component;
     this.props = props;
@@ -74,12 +74,28 @@ export class RenderSnippetConfig<TProps> {
  * ```
  * @see {@link https://tanstack.com/table/latest/docs/guide/column-defs}
  */
+// Overload for components with no required props
+export function renderComponent<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends Component<any>,
+>(
+  component: T,
+): ComponentProps<T> extends Record<string, never> ? RenderComponentConfig<T> : never;
+
+// Overload for components with props
 export function renderComponent<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends Component<any>,
   Props extends ComponentProps<T>,
->(component: T, props: Props = {} as Props) {
-  return new RenderComponentConfig(component, props);
+>(component: T, props: Props): RenderComponentConfig<T>;
+
+// Implementation
+export function renderComponent<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends Component<any>,
+  Props extends ComponentProps<T>,
+>(component: T, props?: Props) {
+  return new RenderComponentConfig(component, props ?? ({} as Props));
 }
 
 /**
@@ -106,6 +122,18 @@ export function renderComponent<
  * ```
  * @see {@link https://tanstack.com/table/latest/docs/guide/column-defs}
  */
-export function renderSnippet<TProps>(snippet: Snippet<[TProps]>, params: TProps = {} as TProps) {
-  return new RenderSnippetConfig(snippet, params);
+// Overload for snippets with no required params
+export function renderSnippet<TProps>(
+  snippet: Snippet<[TProps]>,
+): TProps extends Record<string, never> ? RenderSnippetConfig<TProps> : never;
+
+// Overload for snippets with params
+export function renderSnippet<TProps>(
+  snippet: Snippet<[TProps]>,
+  params: TProps,
+): RenderSnippetConfig<TProps>;
+
+// Implementation
+export function renderSnippet<TProps>(snippet: Snippet<[TProps]>, params?: TProps) {
+  return new RenderSnippetConfig(snippet, params ?? ({} as TProps));
 }

--- a/src/lib/server/services/event.service.ts
+++ b/src/lib/server/services/event.service.ts
@@ -125,11 +125,9 @@ export const eventService = {
     // Build WHERE conditions
     const conditions = [];
 
-    // Admin sees published + own drafts; others see only published
-    if (role === 'admin' && userId) {
-      conditions.push(
-        sql`(${events.status} = 'published' OR (${events.status} = 'draft' AND ${events.createdBy} = ${userId}))`,
-      );
+    // Admin sees all events (published + all drafts); others see only published
+    if (role === 'admin') {
+      // No status filter for admins - they see everything
     } else {
       conditions.push(eq(events.status, 'published'));
     }

--- a/src/routes/(admin)/admin/events/+page.server.ts
+++ b/src/routes/(admin)/admin/events/+page.server.ts
@@ -1,0 +1,18 @@
+import { eventService } from '$lib/server/services/event.service';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ url, locals }) => {
+  const q = url.searchParams.get('q') ?? undefined;
+  const page = url.searchParams.get('page') ?? undefined;
+  const limit = url.searchParams.get('limit') ?? undefined;
+
+  const result = await eventService.listEvents({
+    q,
+    page,
+    limit,
+    role: locals.user?.role,
+    userId: locals.user?.id,
+  });
+
+  return result;
+};

--- a/src/routes/(admin)/admin/events/+page.svelte
+++ b/src/routes/(admin)/admin/events/+page.svelte
@@ -1,6 +1,45 @@
 <script lang="ts">
+  import { goto, invalidateAll } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
-  import { Plus } from 'lucide-svelte';
+  import * as Table from '$lib/components/ui/table';
+  import { toast } from '$lib/stores/toast';
+  import { api } from '$lib/utils/api';
+  import { Loader, Plus, Send } from 'lucide-svelte';
+
+  let { data } = $props();
+
+  let publishingId = $state<number | null>(null);
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('vi-VN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  async function handlePublish(eventId: number, e: MouseEvent) {
+    e.stopPropagation();
+    if (publishingId) return;
+    publishingId = eventId;
+
+    const { error } = await api.patch(`/events/${eventId}/publish`, {});
+
+    if (!error) {
+      toast.success('Xuất bản sự kiện thành công!');
+      await invalidateAll();
+    }
+
+    publishingId = null;
+  }
+
+  function navigateToEvent(eventId: number) {
+    goto(resolve(`/admin/events/${eventId}`));
+  }
 </script>
 
 <div class="space-y-4 md:space-y-6">
@@ -15,7 +54,95 @@
     </Button>
   </div>
 
-  <div class="rounded-lg border bg-card p-8 text-center md:p-12">
-    <p class="text-muted-foreground">Chưa có sự kiện nào. Hãy tạo sự kiện đầu tiên!</p>
-  </div>
+  {#if data.events.length === 0}
+    <div class="rounded-lg border bg-card p-8 text-center md:p-12">
+      <p class="text-muted-foreground">Chưa có sự kiện nào. Hãy tạo sự kiện đầu tiên!</p>
+    </div>
+  {:else}
+    <div class="rounded-lg border bg-card shadow-sm">
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            <Table.Head>Tên sự kiện</Table.Head>
+            <Table.Head>Địa điểm</Table.Head>
+            <Table.Head>Ngày tổ chức</Table.Head>
+            <Table.Head>Trạng thái</Table.Head>
+            <Table.Head class="text-center">Tổng ghế</Table.Head>
+            <Table.Head class="text-center">Còn trống</Table.Head>
+            <Table.Head class="text-end">Hành động</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {#each data.events as event (event.id)}
+            <Table.Row
+              class="cursor-pointer transition-colors hover:bg-muted/50"
+              onclick={() => navigateToEvent(event.id)}
+            >
+              <Table.Cell class="font-medium">{event.title}</Table.Cell>
+              <Table.Cell>{event.venue}</Table.Cell>
+              <Table.Cell>{formatDate(event.event_date)}</Table.Cell>
+              <Table.Cell>
+                {#if event.status === 'published'}
+                  <Badge variant="default" class="bg-green-600 hover:bg-green-700">
+                    Đã xuất bản
+                  </Badge>
+                {:else}
+                  <Badge variant="secondary">Bản nháp</Badge>
+                {/if}
+              </Table.Cell>
+              <Table.Cell class="text-center">{event.total_seats}</Table.Cell>
+              <Table.Cell class="text-center">{event.available_seats}</Table.Cell>
+              <Table.Cell class="text-end">
+                {#if event.status === 'draft'}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={publishingId === event.id}
+                    onclick={(e) => handlePublish(event.id, e)}
+                  >
+                    {#if publishingId === event.id}
+                      <Loader class="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    {:else}
+                      <Send class="mr-1.5 h-3.5 w-3.5" />
+                    {/if}
+                    Xuất bản
+                  </Button>
+                {:else}
+                  <span class="text-xs text-muted-foreground">—</span>
+                {/if}
+              </Table.Cell>
+            </Table.Row>
+          {/each}
+        </Table.Body>
+      </Table.Root>
+    </div>
+
+    <!-- Pagination -->
+    {#if data.pagination.total_pages > 1}
+      <div class="flex items-center justify-between">
+        <p class="text-sm text-muted-foreground">
+          Trang {data.pagination.page} / {data.pagination.total_pages} — Tổng {data.pagination
+            .total} sự kiện
+        </p>
+        <div class="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={data.pagination.page <= 1}
+            onclick={() => goto(resolve(`?page=${data.pagination.page - 1}`))}
+          >
+            Trước
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={data.pagination.page >= data.pagination.total_pages}
+            onclick={() => goto(resolve(`?page=${data.pagination.page + 1}`))}
+          >
+            Sau
+          </Button>
+        </div>
+      </div>
+    {/if}
+  {/if}
 </div>

--- a/src/routes/(admin)/admin/events/+page.svelte
+++ b/src/routes/(admin)/admin/events/+page.svelte
@@ -36,10 +36,6 @@
 
     publishingId = null;
   }
-
-  function navigateToEvent(eventId: number) {
-    goto(resolve(`/admin/events/${eventId}`));
-  }
 </script>
 
 <div class="space-y-4 md:space-y-6">
@@ -74,11 +70,15 @@
         </Table.Header>
         <Table.Body>
           {#each data.events as event (event.id)}
-            <Table.Row
-              class="cursor-pointer transition-colors hover:bg-muted/50"
-              onclick={() => navigateToEvent(event.id)}
-            >
-              <Table.Cell class="font-medium">{event.title}</Table.Cell>
+            <Table.Row class="transition-colors hover:bg-muted/50">
+              <Table.Cell class="font-medium">
+                <a
+                  href={resolve(`/admin/events/${event.id}`)}
+                  class="block hover:underline focus:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {event.title}
+                </a>
+              </Table.Cell>
               <Table.Cell>{event.venue}</Table.Cell>
               <Table.Cell>{formatDate(event.event_date)}</Table.Cell>
               <Table.Cell>
@@ -129,7 +129,11 @@
             variant="outline"
             size="sm"
             disabled={data.pagination.page <= 1}
-            onclick={() => goto(resolve(`?page=${data.pagination.page - 1}`))}
+            onclick={() => {
+              const params = new URLSearchParams(window.location.search);
+              params.set('page', String(data.pagination.page - 1));
+              goto(resolve(`?${params.toString()}`));
+            }}
           >
             Trước
           </Button>
@@ -137,7 +141,11 @@
             variant="outline"
             size="sm"
             disabled={data.pagination.page >= data.pagination.total_pages}
-            onclick={() => goto(resolve(`?page=${data.pagination.page + 1}`))}
+            onclick={() => {
+              const params = new URLSearchParams(window.location.search);
+              params.set('page', String(data.pagination.page + 1));
+              goto(resolve(`?${params.toString()}`));
+            }}
           >
             Sau
           </Button>

--- a/src/routes/(admin)/admin/events/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/events/[id]/+page.server.ts
@@ -6,16 +6,13 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
   const eventId = Number(params.id);
-  if (Number.isNaN(eventId)) error(404, 'Không tìm thấy sự kiện');
+  if (Number.isNaN(eventId) || !Number.isFinite(eventId) || !Number.isInteger(eventId) || eventId <= 0) {
+    error(404, 'Không tìm thấy sự kiện');
+  }
 
   // 1. Get event
   const [event] = await db.select().from(events).where(eq(events.id, eventId)).limit(1);
   if (!event) error(404, 'Không tìm thấy sự kiện');
-
-  // Draft events: only the creator admin can see
-  if (event.status === 'draft' && event.createdBy !== locals.user?.id) {
-    error(404, 'Không tìm thấy sự kiện');
-  }
 
   // 2. Get sections ordered by sort_order
   const sections = await db

--- a/src/routes/(admin)/admin/events/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/events/[id]/+page.server.ts
@@ -1,0 +1,103 @@
+import { db } from '$lib/server/db';
+import { events, seatSections, seats } from '$lib/server/db/schema';
+import { error } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params, locals }) => {
+  const eventId = Number(params.id);
+  if (Number.isNaN(eventId)) error(404, 'Không tìm thấy sự kiện');
+
+  // 1. Get event
+  const [event] = await db.select().from(events).where(eq(events.id, eventId)).limit(1);
+  if (!event) error(404, 'Không tìm thấy sự kiện');
+
+  // Draft events: only the creator admin can see
+  if (event.status === 'draft' && event.createdBy !== locals.user?.id) {
+    error(404, 'Không tìm thấy sự kiện');
+  }
+
+  // 2. Get sections ordered by sort_order
+  const sections = await db
+    .select()
+    .from(seatSections)
+    .where(eq(seatSections.eventId, eventId))
+    .orderBy(seatSections.sortOrder);
+
+  // 3. Get all seats for this event
+  const allSeats = await db
+    .select({
+      id: seats.id,
+      sectionId: seats.sectionId,
+      prefix: seats.prefix,
+      rowLabel: seats.rowLabel,
+      colNumber: seats.colNumber,
+      status: seats.status,
+    })
+    .from(seats)
+    .where(eq(seats.eventId, eventId));
+
+  // 4. Group seats by section
+  const seatsBySection = new Map<number, typeof allSeats>();
+  for (const seat of allSeats) {
+    const list = seatsBySection.get(seat.sectionId) ?? [];
+    list.push(seat);
+    seatsBySection.set(seat.sectionId, list);
+  }
+
+  // 5. Build response
+  const sectionsData = sections.map((s) => {
+    const sectionSeats = seatsBySection.get(s.id) ?? [];
+
+    // Count stats (exclude disabled from total)
+    let available = 0;
+    let locked = 0;
+    let sold = 0;
+    let disabled = 0;
+    for (const seat of sectionSeats) {
+      if (seat.status === 'available') available++;
+      else if (seat.status === 'locked') locked++;
+      else if (seat.status === 'sold') sold++;
+      else if (seat.status === 'disabled') disabled++;
+    }
+    const totalActive = available + locked + sold;
+
+    // Build seat grid: map of "rowLabel" -> map of colNumber -> status (including disabled)
+    const seatGrid: Record<string, Record<number, { status: string; label: string }>> = {};
+    for (const seat of sectionSeats) {
+      if (!seatGrid[seat.rowLabel]) seatGrid[seat.rowLabel] = {};
+      seatGrid[seat.rowLabel][seat.colNumber] = {
+        status: seat.status,
+        label: `${seat.prefix}-${seat.rowLabel}${seat.colNumber}`,
+      };
+    }
+
+    return {
+      id: s.id,
+      name: s.name,
+      prefix: s.prefix,
+      price: Number(s.price),
+      rows: s.rows,
+      cols: s.cols,
+      layoutX: s.layoutX,
+      layoutY: s.layoutY,
+      startRowIndex: s.startRowIndex,
+      startColIndex: s.startColIndex,
+      stats: { total: totalActive, available, locked, sold, disabled },
+      seatGrid,
+    };
+  });
+
+  return {
+    event: {
+      id: event.id,
+      title: event.title,
+      description: event.description,
+      venue: event.venue,
+      eventDate: event.eventDate.toISOString(),
+      bannerImageUrl: event.bannerImageUrl,
+      status: event.status,
+    },
+    sections: sectionsData,
+  };
+};

--- a/src/routes/(admin)/admin/events/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/events/[id]/+page.svelte
@@ -1,12 +1,32 @@
 <script lang="ts">
+  import { invalidateAll } from '$app/navigation';
   import { resolve } from '$app/paths';
+  import * as AlertDialog from '$lib/components/ui/alert-dialog';
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
   import * as Tooltip from '$lib/components/ui/tooltip';
+  import { toast } from '$lib/stores/toast';
+  import { api } from '$lib/utils/api';
   import { getRowLabel } from '$lib/utils/seat-label';
-  import { ArrowLeft } from 'lucide-svelte';
+  import { ArrowLeft, Globe, Loader } from 'lucide-svelte';
   import { SvelteMap } from 'svelte/reactivity';
   let { data } = $props();
+
+  let publishing = $state(false);
+
+  async function handlePublish() {
+    publishing = true;
+    const { error } = await api.patch(`/events/${event.id}/publish`, {});
+    publishing = false;
+
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    toast.success('Sự kiện đã được xuất bản thành công!');
+    await invalidateAll();
+  }
 
   const event = $derived(data.event);
   const sections = $derived(data.sections);
@@ -219,64 +239,125 @@
           <p class="mt-2 max-w-2xl text-sm text-muted-foreground">{event.description}</p>
         {/if}
       </div>
+
+      {#if event.status !== 'published'}
+        <div class="shrink-0">
+          <AlertDialog.Root>
+            <AlertDialog.Trigger>
+              {#snippet child({ props })}
+                <Button {...props} class="gap-2 " disabled={publishing}>
+                  {#if publishing}
+                    <Loader class="h-4 w-4 animate-spin" />
+                  {:else}
+                    <Globe class="h-4 w-4" />
+                  {/if}
+                  Xuất bản sự kiện
+                </Button>
+              {/snippet}
+            </AlertDialog.Trigger>
+            <AlertDialog.Content>
+              <AlertDialog.Header>
+                <AlertDialog.Title>Xuất bản sự kiện?</AlertDialog.Title>
+                <AlertDialog.Description>
+                  Sau khi xuất bản, sự kiện sẽ hiển thị công khai và khách hàng có thể đặt vé. Bạn
+                  sẽ không thể thay đổi sơ đồ ghế nữa.
+                </AlertDialog.Description>
+              </AlertDialog.Header>
+              <AlertDialog.Footer>
+                <AlertDialog.Cancel>Huỷ bỏ</AlertDialog.Cancel>
+                <AlertDialog.Action onclick={handlePublish}>Xuất bản</AlertDialog.Action>
+              </AlertDialog.Footer>
+            </AlertDialog.Content>
+          </AlertDialog.Root>
+        </div>
+      {/if}
     </div>
   </div>
 
   <!-- Overall stats — Bento grid -->
-  <div class="grid grid-cols-2 gap-3 md:grid-cols-5">
-    <!-- Total -->
-    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
-      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-blue-500/10"></div>
-      <div class="relative">
-        <div class="mb-2 h-1.5 w-6 rounded-full bg-blue-500"></div>
-        <p class="text-2xl font-bold tracking-tight text-blue-600">{totalStats.total}</p>
-        <p class="text-xs font-medium text-muted-foreground">Tổng ghế</p>
+  <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
+    <!-- Hero tile: Tổng ghế — spans 2 cols on all, + 2 rows on md -->
+    <div
+      class="relative col-span-2 overflow-hidden rounded-3xl border bg-card p-6 shadow-sm transition-shadow hover:shadow-md md:row-span-2 md:p-8"
+    >
+      <!-- Decorative blobs -->
+      <div class="absolute -top-8 -right-8 h-32 w-32 rounded-full bg-blue-500/8 blur-md"></div>
+      <div class="absolute -bottom-6 -left-6 h-24 w-24 rounded-full bg-blue-400/6 blur-lg"></div>
+
+      <div class="relative flex h-full flex-col justify-between">
+        <div>
+          <div class="mb-3 inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1">
+            <div class="h-2 w-2 rounded-full bg-blue-500"></div>
+            <span
+              class="text-xs font-semibold tracking-wide text-blue-600 uppercase dark:text-blue-400"
+            >
+              Tổng ghế
+            </span>
+          </div>
+          <p
+            class="text-5xl font-extrabold tracking-tighter text-blue-600 md:text-6xl dark:text-blue-400"
+          >
+            {totalStats.total.toLocaleString('vi-VN')}
+          </p>
+        </div>
+        <p class="mt-4 text-sm text-muted-foreground">
+          {totalStats.available} trống · {totalStats.locked} giữ · {totalStats.sold} bán · {totalStats.disabled}
+          vô hiệu
+        </p>
       </div>
     </div>
 
     <!-- Available -->
-    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
-      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-green-500/10"></div>
+    <div
+      class="relative overflow-hidden rounded-3xl border bg-card p-5 shadow-sm transition-shadow hover:shadow-md"
+    >
+      <div class="absolute -top-4 -right-4 h-16 w-16 rounded-full bg-green-500/10 blur-sm"></div>
       <div class="relative">
         <div class="mb-2 h-1.5 w-6 rounded-full bg-green-500"></div>
         <p class="text-2xl font-bold tracking-tight text-green-600">{totalStats.available}</p>
-        <p class="text-xs font-medium text-muted-foreground">Còn trống</p>
+        <p class="mt-0.5 text-xs font-medium text-muted-foreground">Còn trống</p>
       </div>
     </div>
 
     <!-- Locked -->
-    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
-      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-red-500/10"></div>
+    <div
+      class="relative overflow-hidden rounded-3xl border bg-card p-5 shadow-sm transition-shadow hover:shadow-md"
+    >
+      <div class="absolute -top-4 -right-4 h-16 w-16 rounded-full bg-red-500/10 blur-sm"></div>
       <div class="relative">
         <div class="mb-2 h-1.5 w-6 rounded-full bg-red-500"></div>
         <p class="text-2xl font-bold tracking-tight text-red-600">{totalStats.locked}</p>
-        <p class="text-xs font-medium text-muted-foreground">Đang giữ</p>
+        <p class="mt-0.5 text-xs font-medium text-muted-foreground">Đang giữ</p>
       </div>
     </div>
 
     <!-- Sold -->
-    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
-      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-gray-500/10"></div>
+    <div
+      class="relative overflow-hidden rounded-3xl border bg-card p-5 shadow-sm transition-shadow hover:shadow-md"
+    >
+      <div class="absolute -top-4 -right-4 h-16 w-16 rounded-full bg-gray-500/10 blur-sm"></div>
       <div class="relative">
-        <div class="mb-2 h-1.5 w-6 rounded-full bg-gray-800 dark:bg-gray-500"></div>
+        <div class="mb-2 h-1.5 w-6 rounded-full bg-gray-800/80 dark:bg-gray-500"></div>
         <p class="text-2xl font-bold tracking-tight text-gray-700 dark:text-gray-400">
           {totalStats.sold}
         </p>
-        <p class="text-xs font-medium text-muted-foreground">Đã bán</p>
+        <p class="mt-0.5 text-xs font-medium text-muted-foreground">Đã bán</p>
       </div>
     </div>
 
     <!-- Disabled -->
-    <div class="relative overflow-hidden rounded-2xl border border-dashed bg-card p-5 shadow-sm">
+    <div
+      class="relative overflow-hidden rounded-3xl border border-dashed bg-card p-5 shadow-sm transition-shadow hover:shadow-md"
+    >
       <div
-        class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-gray-300/10 dark:bg-gray-700/10"
+        class="absolute -top-4 -right-4 h-16 w-16 rounded-full bg-gray-300/10 blur-sm dark:bg-gray-700/10"
       ></div>
       <div class="relative">
         <div class="mb-2 h-1.5 w-6 rounded-full bg-gray-300 dark:bg-gray-700"></div>
         <p class="text-2xl font-bold tracking-tight text-gray-400 dark:text-gray-600">
           {totalStats.disabled}
         </p>
-        <p class="text-xs font-medium text-muted-foreground">Vô hiệu</p>
+        <p class="mt-0.5 text-xs font-medium text-muted-foreground">Vô hiệu</p>
       </div>
     </div>
   </div>

--- a/src/routes/(admin)/admin/events/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/events/[id]/+page.svelte
@@ -385,7 +385,7 @@
               class="flex h-7 items-center justify-center text-xs font-semibold text-muted-foreground"
               style="grid-row: {rh.gridRow + 1}; grid-column: 1;"
             >
-              {rh.label}
+              {rh.coordY}
             </div>
           {/each}
 

--- a/src/routes/(admin)/admin/events/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/events/[id]/+page.svelte
@@ -1,0 +1,520 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
+  import * as Tooltip from '$lib/components/ui/tooltip';
+  import { getRowLabel } from '$lib/utils/seat-label';
+  import { ArrowLeft } from 'lucide-svelte';
+  import { SvelteMap } from 'svelte/reactivity';
+  let { data } = $props();
+
+  const event = $derived(data.event);
+  const sections = $derived(data.sections);
+
+  // View mode: 'overview' = combined map, null = all sections separately, number = specific section
+  let viewMode = $state<'overview' | null | number>('overview');
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('vi-VN', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(price);
+  };
+
+  // Overall stats
+  const totalStats = $derived.by(() => {
+    let available = 0;
+    let locked = 0;
+    let sold = 0;
+    let disabled = 0;
+    let total = 0;
+    for (const s of sections) {
+      available += s.stats.available;
+      locked += s.stats.locked;
+      sold += s.stats.sold;
+      disabled += s.stats.disabled;
+      total += s.stats.total;
+    }
+    return { available, locked, sold, disabled, total };
+  });
+
+  // Build combined grid for "Tổng quan" view using CSS Grid positioning
+  // Each section reserves extra rows: 1 for section name label, 1 for column numbers, then seat rows
+  type CombinedCell = { status: string; label: string; sectionName: string };
+
+  type OverviewData = {
+    cells: Map<string, CombinedCell>; // key: "gridRow,gridCol"
+    totalGridRows: number;
+    totalGridCols: number; // +1 for row label column
+    sectionHeaders: { name: string; gridRow: number; gridColStart: number; gridColEnd: number }[];
+    colHeaders: { num: number; gridRow: number; gridCol: number }[];
+    rowHeaders: { coordY: number; gridRow: number }[]; // numeric grid coordinate
+  };
+
+  const overview = $derived.by((): OverviewData => {
+    const cells = new SvelteMap<string, CombinedCell>();
+    const sectionHeaders: OverviewData['sectionHeaders'] = [];
+    const colHeaders: OverviewData['colHeaders'] = [];
+    const rowHeaders: OverviewData['rowHeaders'] = [];
+    let maxGridCol = 1; // col 0 is for row labels
+
+    // Sort sections by layoutY then layoutX for deterministic ordering
+    const sorted = [...sections].sort((a, b) => a.layoutY - b.layoutY || a.layoutX - b.layoutX);
+
+    // Group sections by layoutY to find unique "bands"
+    const bandMap = new SvelteMap<number, typeof sorted>();
+    for (const sec of sorted) {
+      const band = bandMap.get(sec.layoutY) ?? [];
+      band.push(sec);
+      bandMap.set(sec.layoutY, band);
+    }
+    const bandKeys = [...bandMap.keys()].sort((a, b) => a - b);
+
+    let gridRow = 0;
+    for (const bandY of bandKeys) {
+      const bandSections = bandMap.get(bandY)!;
+      const sectionLabelRow = gridRow;
+      gridRow++;
+      const colHeaderRow = gridRow;
+      gridRow++;
+      const dataStartRow = gridRow;
+
+      // Find max rows in this band
+      let maxRows = 0;
+      for (const sec of bandSections) {
+        if (sec.rows > maxRows) maxRows = sec.rows;
+
+        // gridCol offset: col 0 = row labels, so section starts at layoutX + 1
+        const gcStart = sec.layoutX + 1;
+        const gcEnd = gcStart + sec.cols;
+
+        // Section header
+        sectionHeaders.push({
+          name: sec.name,
+          gridRow: sectionLabelRow,
+          gridColStart: gcStart,
+          gridColEnd: gcEnd,
+        });
+
+        // Column number headers (show grid X coordinate, not startColIndex)
+        for (let c = 0; c < sec.cols; c++) {
+          colHeaders.push({
+            num: sec.layoutX + c,
+            gridRow: colHeaderRow,
+            gridCol: gcStart + c,
+          });
+        }
+
+        // Seat cells
+        for (let r = 0; r < sec.rows; r++) {
+          const rowLabel = getRowLabel(sec.startRowIndex + r);
+          const seatRow = dataStartRow + r;
+
+          for (let c = 0; c < sec.cols; c++) {
+            const colNum = sec.startColIndex + c;
+            const seatInfo = sec.seatGrid[rowLabel]?.[colNum];
+            if (seatInfo) {
+              cells.set(`${seatRow},${gcStart + c}`, {
+                status: seatInfo.status,
+                label: seatInfo.label,
+                sectionName: sec.name,
+              });
+            }
+          }
+        }
+
+        if (gcEnd > maxGridCol) maxGridCol = gcEnd;
+      }
+
+      // Row labels — use numeric grid Y coordinate instead of letters
+      for (let r = 0; r < maxRows; r++) {
+        rowHeaders.push({ coordY: bandY + r, gridRow: dataStartRow + r });
+      }
+
+      gridRow += maxRows;
+    }
+
+    return {
+      cells,
+      totalGridRows: gridRow,
+      totalGridCols: maxGridCol,
+      sectionHeaders,
+      colHeaders,
+      rowHeaders,
+    };
+  });
+
+  // Filtered sections for individual view
+  const visibleSections = $derived.by(() => {
+    if (viewMode === 'overview') return [];
+    if (viewMode === null) return sections;
+    return sections.filter((s) => s.id === viewMode);
+  });
+
+  // Stats for currently visible section
+  const selectedSection = $derived(
+    typeof viewMode === 'number' ? sections.find((s) => s.id === viewMode) : null,
+  );
+
+  function seatColor(status: string): string {
+    switch (status) {
+      case 'available':
+        return 'bg-green-500 hover:bg-green-600 text-white';
+      case 'locked':
+        return 'bg-red-500 hover:bg-red-600 text-white';
+      case 'sold':
+        return 'bg-gray-800 hover:bg-gray-900 dark:bg-gray-600 dark:hover:bg-gray-500 text-white';
+      case 'disabled':
+        return 'bg-gray-200 dark:bg-gray-800 text-gray-400 dark:text-gray-600';
+      default:
+        return 'bg-gray-300 text-gray-500';
+    }
+  }
+
+  function statusLabelVi(status: string): string {
+    switch (status) {
+      case 'available':
+        return 'Còn trống';
+      case 'locked':
+        return 'Đang giữ';
+      case 'sold':
+        return 'Đã bán';
+      case 'disabled':
+        return 'Vô hiệu';
+      default:
+        return status;
+    }
+  }
+</script>
+
+<div class="space-y-6 md:space-y-8">
+  <!-- Back + Header -->
+  <div class="space-y-4">
+    <Button variant="ghost" size="sm" href={resolve('/admin/events')}>
+      <ArrowLeft class="mr-2 h-4 w-4" />
+      Quay lại danh sách
+    </Button>
+
+    <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div class="space-y-1">
+        <div class="flex items-center gap-3">
+          <h1 class="text-xl font-bold tracking-tight md:text-2xl">{event.title}</h1>
+          {#if event.status === 'published'}
+            <Badge variant="default" class="bg-green-600 hover:bg-green-700">Đã xuất bản</Badge>
+          {:else}
+            <Badge variant="secondary">Bản nháp</Badge>
+          {/if}
+        </div>
+        <p class="text-sm text-muted-foreground">📍 {event.venue}</p>
+        <p class="text-sm text-muted-foreground">📅 {formatDate(event.eventDate)}</p>
+        {#if event.description}
+          <p class="mt-2 max-w-2xl text-sm text-muted-foreground">{event.description}</p>
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <!-- Overall stats — Bento grid -->
+  <div class="grid grid-cols-2 gap-3 md:grid-cols-5">
+    <!-- Total -->
+    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
+      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-blue-500/10"></div>
+      <div class="relative">
+        <div class="mb-2 h-1.5 w-6 rounded-full bg-blue-500"></div>
+        <p class="text-2xl font-bold tracking-tight text-blue-600">{totalStats.total}</p>
+        <p class="text-xs font-medium text-muted-foreground">Tổng ghế</p>
+      </div>
+    </div>
+
+    <!-- Available -->
+    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
+      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-green-500/10"></div>
+      <div class="relative">
+        <div class="mb-2 h-1.5 w-6 rounded-full bg-green-500"></div>
+        <p class="text-2xl font-bold tracking-tight text-green-600">{totalStats.available}</p>
+        <p class="text-xs font-medium text-muted-foreground">Còn trống</p>
+      </div>
+    </div>
+
+    <!-- Locked -->
+    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
+      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-red-500/10"></div>
+      <div class="relative">
+        <div class="mb-2 h-1.5 w-6 rounded-full bg-red-500"></div>
+        <p class="text-2xl font-bold tracking-tight text-red-600">{totalStats.locked}</p>
+        <p class="text-xs font-medium text-muted-foreground">Đang giữ</p>
+      </div>
+    </div>
+
+    <!-- Sold -->
+    <div class="relative overflow-hidden rounded-2xl border bg-card p-5 shadow-sm">
+      <div class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-gray-500/10"></div>
+      <div class="relative">
+        <div class="mb-2 h-1.5 w-6 rounded-full bg-gray-800 dark:bg-gray-500"></div>
+        <p class="text-2xl font-bold tracking-tight text-gray-700 dark:text-gray-400">
+          {totalStats.sold}
+        </p>
+        <p class="text-xs font-medium text-muted-foreground">Đã bán</p>
+      </div>
+    </div>
+
+    <!-- Disabled -->
+    <div class="relative overflow-hidden rounded-2xl border border-dashed bg-card p-5 shadow-sm">
+      <div
+        class="absolute -top-3 -right-3 h-16 w-16 rounded-full bg-gray-300/10 dark:bg-gray-700/10"
+      ></div>
+      <div class="relative">
+        <div class="mb-2 h-1.5 w-6 rounded-full bg-gray-300 dark:bg-gray-700"></div>
+        <p class="text-2xl font-bold tracking-tight text-gray-400 dark:text-gray-600">
+          {totalStats.disabled}
+        </p>
+        <p class="text-xs font-medium text-muted-foreground">Vô hiệu</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Legend -->
+  <div class="flex flex-wrap items-center gap-4 text-sm">
+    <span class="font-medium">Chú thích:</span>
+    <span class="flex items-center gap-1.5">
+      <span class="inline-block h-4 w-4 rounded bg-green-500"></span>
+      Còn trống
+    </span>
+    <span class="flex items-center gap-1.5">
+      <span class="inline-block h-4 w-4 rounded bg-red-500"></span>
+      Đang giữ
+    </span>
+    <span class="flex items-center gap-1.5">
+      <span class="inline-block h-4 w-4 rounded bg-gray-800 dark:bg-gray-600"></span>
+      Đã bán
+    </span>
+    <span class="flex items-center gap-1.5">
+      <span
+        class="inline-block h-4 w-4 rounded border border-dashed border-gray-400 bg-gray-200 dark:bg-gray-800"
+      ></span>
+      Vô hiệu
+    </span>
+  </div>
+
+  <!-- View mode selector -->
+  {#if sections.length > 0}
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="text-sm font-medium">Xem:</span>
+      <Button
+        size="sm"
+        variant={viewMode === 'overview' ? 'default' : 'outline'}
+        onclick={() => (viewMode = 'overview')}
+      >
+        Tổng quan
+      </Button>
+      <Button
+        size="sm"
+        variant={viewMode === null ? 'default' : 'outline'}
+        onclick={() => (viewMode = null)}
+      >
+        Tất cả khu vực
+      </Button>
+      {#each sections as section (section.id)}
+        <Button
+          size="sm"
+          variant={viewMode === section.id ? 'default' : 'outline'}
+          onclick={() => (viewMode = section.id)}
+        >
+          {section.name}
+        </Button>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Selected section info -->
+  {#if selectedSection}
+    <div class="rounded-lg border bg-muted/30 p-3 text-sm">
+      <span class="font-semibold">{selectedSection.name}</span>
+      <span class="ml-2 text-muted-foreground">
+        — Giá: {formatPrice(selectedSection.price)}
+        — {selectedSection.stats.available} còn trống, {selectedSection.stats.locked} đang giữ, {selectedSection
+          .stats.sold} đã bán, {selectedSection.stats.disabled} vô hiệu (Tổng: {selectedSection
+          .stats.total + selectedSection.stats.disabled})
+      </span>
+    </div>
+  {/if}
+
+  <!-- ═══ OVERVIEW: Combined seat map ═══ -->
+  {#if viewMode === 'overview' && sections.length > 0}
+    <div class="rounded-lg border bg-card p-4 shadow-sm md:p-6">
+      <h2 class="mb-4 text-base font-semibold">Sơ đồ tổng quan</h2>
+
+      <div class="overflow-x-auto">
+        <div
+          class="inline-grid gap-1"
+          style="grid-template-columns: 2rem repeat({overview.totalGridCols -
+            1}, 1.75rem); grid-template-rows: repeat({overview.totalGridRows}, auto);"
+        >
+          <!-- Section name headers -->
+          {#each overview.sectionHeaders as sh (sh.name + sh.gridRow)}
+            <div
+              class="flex items-end pb-0.5 text-xs font-semibold text-primary"
+              style="grid-row: {sh.gridRow + 1}; grid-column: {sh.gridColStart +
+                1} / {sh.gridColEnd + 1};"
+            >
+              ▸ {sh.name}
+            </div>
+          {/each}
+
+          <!-- Column number headers -->
+          {#each overview.colHeaders as ch (`ch-${ch.gridRow}-${ch.gridCol}`)}
+            <div
+              class="flex h-5 items-center justify-center text-[10px] font-medium text-muted-foreground"
+              style="grid-row: {ch.gridRow + 1}; grid-column: {ch.gridCol + 1};"
+            >
+              {ch.num}
+            </div>
+          {/each}
+
+          <!-- Row labels -->
+          {#each overview.rowHeaders as rh (`rh-${rh.gridRow}`)}
+            <div
+              class="flex h-7 items-center justify-center text-xs font-semibold text-muted-foreground"
+              style="grid-row: {rh.gridRow + 1}; grid-column: 1;"
+            >
+              {rh.label}
+            </div>
+          {/each}
+
+          <!-- Seat cells -->
+          {#each [...overview.cells.entries()] as [key, cell] (key)}
+            {@const [r, c] = key.split(',').map(Number)}
+            <div style="grid-row: {r + 1}; grid-column: {c + 1};">
+              <Tooltip.Root>
+                <Tooltip.Trigger>
+                  {#if cell.status === 'disabled'}
+                    <div
+                      class="flex h-7 w-7 cursor-default items-center justify-center rounded border border-dashed border-gray-300 text-[9px] dark:border-gray-700 {seatColor(
+                        cell.status,
+                      )}"
+                    >
+                      ✕
+                    </div>
+                  {:else}
+                    <div
+                      class="flex h-7 w-7 cursor-default items-center justify-center rounded text-[10px] font-medium transition-colors {seatColor(
+                        cell.status,
+                      )}"
+                    ></div>
+                  {/if}
+                </Tooltip.Trigger>
+                <Tooltip.Content>
+                  <p class="font-medium">{cell.label}</p>
+                  <p class="text-xs opacity-80">
+                    {cell.sectionName} — {statusLabelVi(cell.status)}
+                  </p>
+                </Tooltip.Content>
+              </Tooltip.Root>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <!-- ═══ INDIVIDUAL SECTION VIEWS ═══ -->
+  {#if viewMode !== 'overview'}
+    {#each visibleSections as section (section.id)}
+      <div class="rounded-lg border bg-card p-4 shadow-sm md:p-6">
+        <div class="mb-4 flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-base font-semibold">
+              {section.name}
+              <span class="ml-2 text-sm font-normal text-muted-foreground">
+                ({section.stats.total + section.stats.disabled} ghế — {section.stats.total} active)
+              </span>
+            </h2>
+            <p class="text-xs text-muted-foreground">
+              Giá: {formatPrice(section.price)}
+              — {section.stats.available} còn trống, {section.stats.locked} đang giữ, {section.stats
+                .sold} đã bán, {section.stats.disabled} vô hiệu
+            </p>
+          </div>
+        </div>
+
+        <!-- Seat grid -->
+        <div class="overflow-x-auto">
+          <div class="inline-block min-w-fit">
+            <!-- Column headers -->
+            <div class="mb-1 flex items-center gap-1">
+              <div class="w-8 shrink-0"></div>
+              {#each Array.from({ length: section.cols }, (_, i) => section.startColIndex + i) as col (col)}
+                <div
+                  class="flex h-6 w-8 shrink-0 items-center justify-center text-xs font-medium text-muted-foreground"
+                >
+                  {col}
+                </div>
+              {/each}
+            </div>
+
+            <!-- Rows -->
+            {#each Array.from({ length: section.rows }, (_, i) => i) as rowIdx (rowIdx)}
+              {@const rowLabel = getRowLabel(section.startRowIndex + rowIdx)}
+              <div class="mb-1 flex items-center gap-1">
+                <!-- Row label -->
+                <div
+                  class="flex h-8 w-8 shrink-0 items-center justify-center text-xs font-semibold text-muted-foreground"
+                >
+                  {rowLabel}
+                </div>
+
+                <!-- Seats -->
+                {#each Array.from({ length: section.cols }, (_, i) => section.startColIndex + i) as col (col)}
+                  {@const seatInfo = section.seatGrid[rowLabel]?.[col]}
+                  {#if seatInfo}
+                    <Tooltip.Root>
+                      <Tooltip.Trigger>
+                        {#if seatInfo.status === 'disabled'}
+                          <div
+                            class="flex h-8 w-8 shrink-0 cursor-default items-center justify-center rounded border border-dashed border-gray-300 dark:border-gray-700 {seatColor(
+                              seatInfo.status,
+                            )} text-[10px]"
+                          >
+                            ✕
+                          </div>
+                        {:else}
+                          <div
+                            class="flex h-8 w-8 shrink-0 cursor-default items-center justify-center rounded text-xs font-medium transition-colors {seatColor(
+                              seatInfo.status,
+                            )}"
+                          >
+                            {col}
+                          </div>
+                        {/if}
+                      </Tooltip.Trigger>
+                      <Tooltip.Content>
+                        <p>{seatInfo.label} — {statusLabelVi(seatInfo.status)}</p>
+                      </Tooltip.Content>
+                    </Tooltip.Root>
+                  {:else}
+                    <!-- No seat in this position -->
+                    <div class="h-8 w-8 shrink-0"></div>
+                  {/if}
+                {/each}
+              </div>
+            {/each}
+          </div>
+        </div>
+      </div>
+    {/each}
+  {/if}
+
+  {#if sections.length === 0}
+    <div class="rounded-lg border bg-card p-8 text-center md:p-12">
+      <p class="text-muted-foreground">Sự kiện chưa có khu vực ghế nào.</p>
+    </div>
+  {/if}
+</div>

--- a/src/routes/(admin)/admin/events/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/events/[id]/+page.svelte
@@ -61,7 +61,7 @@
       locked += s.stats.locked;
       sold += s.stats.sold;
       disabled += s.stats.disabled;
-      total += s.stats.total;
+      total += s.stats.total + s.stats.disabled;
     }
     return { available, locked, sold, disabled, total };
   });
@@ -475,7 +475,7 @@
             {@const [r, c] = key.split(',').map(Number)}
             <div style="grid-row: {r + 1}; grid-column: {c + 1};">
               <Tooltip.Root>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger aria-label="{cell.label} — {statusLabelVi(cell.status)}">
                   {#if cell.status === 'disabled'}
                     <div
                       class="flex h-7 w-7 cursor-default items-center justify-center rounded border border-dashed border-gray-300 text-[9px] dark:border-gray-700 {seatColor(
@@ -557,7 +557,7 @@
                   {@const seatInfo = section.seatGrid[rowLabel]?.[col]}
                   {#if seatInfo}
                     <Tooltip.Root>
-                      <Tooltip.Trigger>
+                      <Tooltip.Trigger aria-label="{seatInfo.label} — {statusLabelVi(seatInfo.status)}">
                         {#if seatInfo.status === 'disabled'}
                           <div
                             class="flex h-8 w-8 shrink-0 cursor-default items-center justify-center rounded border border-dashed border-gray-300 dark:border-gray-700 {seatColor(

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,7 +4,8 @@ import adapter from 'svelte-adapter-bun';
 // If VITE_API_URL is set to an external origin (e.g. https://api.example.com),
 // we must include it in connect-src so the browser CSP doesn't block fetch requests.
 const apiUrl = process.env.VITE_API_URL || '';
-const connectSrc = /** @type {Array<import('@sveltejs/kit').CspDirectives['connect-src']>[number]>} */ (['self']);
+const connectSrc =
+  /** @type {Array<import('@sveltejs/kit').CspDirectives['connect-src']>[number]>} */ (['self']);
 if (apiUrl) {
   try {
     const origin = new URL(apiUrl).origin; // e.g. "https://api.example.com"


### PR DESCRIPTION
## Mô tả

Thêm UI xem danh sách sự kiện và chi tiết sự kiện cho admin 

Closes #11

## Loại thay đổi

- [x] ✨ Feature mới
- [x] 💄 UI / Style

## Screenshots / Demo

<img width="3064" height="2146" alt="image" src="https://github.com/user-attachments/assets/69707904-7ff4-4d02-a379-1a5e76803459" />

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events list page: tabular view, publish action, per-row loading, and pagination.
  * Event detail page: interactive seat-map management with overview and per-section views, publish workflow, stats and legends.
  * New reusable data-table components and flexible cell/header rendering helpers; server loaders added for admin event pages.

* **Improvements**
  * Preview grid now uses numeric row coordinates; section items auto-sync layout coordinates to start indexes.

* **Bug Fixes**
  * Admin users now see events across all statuses (broader visibility).

* **Chores**
  * Added a table runtime dependency for data-table functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->