### PR TITLE
feat(db): expand event and seat schemas with additional fields and status options

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -2,6 +2,7 @@
 import { sql } from 'drizzle-orm';
 import {
   boolean,
+  check,
   date,
   decimal,
   index,
@@ -48,31 +49,38 @@ export const users = pgTable('users', {
 });
 
 // ── Events ─────────────────────────────────────
-export const events = pgTable('events', {
-  id: serial('id').primaryKey(),
-  title: varchar('title', { length: 200 }).notNull(),
-  description: text('description').notNull(),
-  venue: varchar('venue', { length: 200 }).notNull(),
-  eventDate: timestamp('event_date', { withTimezone: true }).notNull(),
-  bannerImageUrl: varchar('banner_image_url', { length: 500 }),
-  minAge: integer('min_age').notNull().default(0), // 0 là mọi lứa tuổi
-  maxTicketsPerUser: integer('max_tickets_per_user').notNull().default(0), // 0 là không giới hạn
-  stageLayout: jsonb('stage_layout').default([]),
-  /* Ví dụ data bên trong:
-     [
-       { "id": "main", "label": "Sân khấu chính", "type": "rect", "x": 10, "y": 0, "w": 20, "h": 5 },
-       { "id": "catwalk", "label": "Đường băng", "type": "rect", "x": 18, "y": 5, "w": 4, "h": 10 },
-       { "id": "center", "label": "Center Stage", "type": "circle", "x": 20, "y": 20, "radius": 8 }
-     ]
-  */
+export const events = pgTable(
+  'events',
+  {
+    id: serial('id').primaryKey(),
+    title: varchar('title', { length: 200 }).notNull(),
+    description: text('description').notNull(),
+    venue: varchar('venue', { length: 200 }).notNull(),
+    eventDate: timestamp('event_date', { withTimezone: true }).notNull(),
+    bannerImageUrl: varchar('banner_image_url', { length: 500 }),
+    minAge: integer('min_age').notNull().default(0), // 0 là mọi lứa tuổi
+    maxTicketsPerUser: integer('max_tickets_per_user').notNull().default(0), // 0 là không giới hạn
+    stageLayout: jsonb('stage_layout').default([]),
+    /* Ví dụ data bên trong:
+       [
+         { "id": "main", "label": "Sân khấu chính", "type": "rect", "x": 10, "y": 0, "w": 20, "h": 5 },
+         { "id": "catwalk", "label": "Đường băng", "type": "rect", "x": 18, "y": 5, "w": 4, "h": 10 },
+         { "id": "center", "label": "Center Stage", "type": "circle", "x": 20, "y": 20, "radius": 8 }
+       ]
+    */
 
-  status: eventStatusEnum('status').notNull().default('draft'),
-  createdBy: integer('created_by')
-    .notNull()
-    .references(() => users.id),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
-});
+    status: eventStatusEnum('status').notNull().default('draft'),
+    createdBy: integer('created_by')
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    check('chk_min_age_non_negative', sql`${table.minAge} >= 0`),
+    check('chk_max_tickets_per_user_non_negative', sql`${table.maxTicketsPerUser} >= 0`),
+  ],
+);
 
 // ── Seat Sections ──────────────────────────────
 export const seatSections = pgTable(
@@ -156,18 +164,27 @@ export const orders = pgTable(
 );
 
 // ── Order Items ────────────────────────────────
-export const orderItems = pgTable('order_items', {
-  id: serial('id').primaryKey(),
-  orderId: integer('order_id')
-    .notNull()
-    .references(() => orders.id),
-  seatId: integer('seat_id')
-    .notNull()
-    .references(() => seats.id),
-  priceSnapshot: decimal('price_snapshot', { precision: 12, scale: 2 }).notNull(),
-  qrCode: text('qr_code'),
-  isCheckedIn: boolean('is_checked_in').notNull().default(false),
-  checkedInAt: timestamp('checked_in_at', { withTimezone: true }),
+export const orderItems = pgTable(
+  'order_items',
+  {
+    id: serial('id').primaryKey(),
+    orderId: integer('order_id')
+      .notNull()
+      .references(() => orders.id),
+    seatId: integer('seat_id')
+      .notNull()
+      .references(() => seats.id),
+    priceSnapshot: decimal('price_snapshot', { precision: 12, scale: 2 }).notNull(),
+    qrCode: text('qr_code'),
+    isCheckedIn: boolean('is_checked_in').notNull().default(false),
+    checkedInAt: timestamp('checked_in_at', { withTimezone: true }),
 
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-});
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    check(
+      'chk_checked_in_consistency',
+      sql`${table.isCheckedIn} = (${table.checkedInAt} IS NOT NULL)`,
+    ),
+  ],
+);

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -6,6 +6,7 @@ import {
   decimal,
   index,
   integer,
+  jsonb,
   pgEnum,
   pgTable,
   serial,
@@ -18,8 +19,16 @@ import {
 // ── Enums ──────────────────────────────────────
 export const roleEnum = pgEnum('role', ['admin', 'customer']);
 export const genderEnum = pgEnum('gender', ['male', 'female', 'other']);
-export const eventStatusEnum = pgEnum('event_status', ['draft', 'published']);
+
+export const eventStatusEnum = pgEnum('event_status', [
+  'draft',
+  'published',
+  'sold_out',
+  'completed',
+  'cancelled',
+]);
 export const seatStatusEnum = pgEnum('seat_status', ['available', 'locked', 'sold', 'disabled']);
+export const seatTypeEnum = pgEnum('seat_type', ['assigned', 'general']);
 export const orderStatusEnum = pgEnum('order_status', ['pending', 'paid', 'cancelled']);
 
 // ── Users ──────────────────────────────────────
@@ -46,6 +55,17 @@ export const events = pgTable('events', {
   venue: varchar('venue', { length: 200 }).notNull(),
   eventDate: timestamp('event_date', { withTimezone: true }).notNull(),
   bannerImageUrl: varchar('banner_image_url', { length: 500 }),
+  minAge: integer('min_age').notNull().default(0), // 0 là mọi lứa tuổi
+  maxTicketsPerUser: integer('max_tickets_per_user').notNull().default(0), // 0 là không giới hạn
+  stageLayout: jsonb('stage_layout').default([]),
+  /* Ví dụ data bên trong:
+     [
+       { "id": "main", "label": "Sân khấu chính", "type": "rect", "x": 10, "y": 0, "w": 20, "h": 5 },
+       { "id": "catwalk", "label": "Đường băng", "type": "rect", "x": 18, "y": 5, "w": 4, "h": 10 },
+       { "id": "center", "label": "Center Stage", "type": "circle", "x": 20, "y": 20, "radius": 8 }
+     ]
+  */
+
   status: eventStatusEnum('status').notNull().default('draft'),
   createdBy: integer('created_by')
     .notNull()
@@ -63,7 +83,9 @@ export const seatSections = pgTable(
       .notNull()
       .references(() => events.id),
     name: varchar('name', { length: 50 }).notNull(),
+    type: seatTypeEnum('type').notNull().default('assigned'),
     prefix: varchar('prefix', { length: 10 }).notNull(),
+    isSeatPickable: boolean('is_pickable').notNull().default(true),
     rows: integer('rows').notNull(),
     cols: integer('cols').notNull(),
     price: decimal('price', { precision: 12, scale: 2 }).notNull(),
@@ -144,5 +166,8 @@ export const orderItems = pgTable('order_items', {
     .references(() => seats.id),
   priceSnapshot: decimal('price_snapshot', { precision: 12, scale: 2 }).notNull(),
   qrCode: text('qr_code'),
+  isCheckedIn: boolean('is_checked_in').notNull().default(false),
+  checkedInAt: timestamp('checked_in_at', { withTimezone: true }),
+
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -31,7 +31,9 @@ function getRowLabel(index: number): string {
 
 interface SectionSeed {
   name: string;
+  type?: 'assigned' | 'general';
   prefix: string;
+  isSeatPickable?: boolean;
   rows: number;
   cols: number;
   price: string;
@@ -270,7 +272,9 @@ async function createSections(eventId: number, sections: SectionSeed[]) {
       .values({
         eventId,
         name: s.name,
+        type: s.type ?? 'assigned',
         prefix: s.prefix,
+        isSeatPickable: s.isSeatPickable ?? true,
         rows: s.rows,
         cols: s.cols,
         price: s.price,

--- a/src/lib/server/services/event.service.ts
+++ b/src/lib/server/services/event.service.ts
@@ -77,7 +77,9 @@ async function insertSectionsWithSeats(
       .values({
         eventId,
         name: sec.name,
+        type: sec.type,
         prefix: sec.prefix,
+        isSeatPickable: sec.is_seat_pickable,
         rows: sec.rows,
         cols: sec.cols,
         price: String(sec.price),
@@ -125,11 +127,12 @@ export const eventService = {
     // Build WHERE conditions
     const conditions = [];
 
-    // Admin sees all events (published + all drafts); others see only published
+    // Admin sees all events; non-admins see all public statuses (published, sold_out, completed, cancelled)
     if (role === 'admin') {
       // No status filter for admins - they see everything
     } else {
-      conditions.push(eq(events.status, 'published'));
+      // Exclude only draft status - all other statuses are public
+      conditions.push(sql`${events.status} != 'draft'`);
     }
 
     if (q) {
@@ -192,7 +195,8 @@ export const eventService = {
     if (!event) throwError(Errors.NOT_FOUND);
 
     // Draft events are only visible to the admin who created them
-    if (event.status !== 'published') {
+    // Other statuses (published, sold_out, completed, cancelled) are public
+    if (event.status === 'draft') {
       if (role !== 'admin' || event.createdBy !== userId) {
         throwError(Errors.NOT_FOUND);
       }
@@ -246,7 +250,9 @@ export const eventService = {
         return {
           id: s.id,
           name: s.name,
+          type: s.type,
           prefix: s.prefix,
+          is_seat_pickable: s.isSeatPickable,
           price: Number(s.price),
           rows: s.rows,
           cols: s.cols,

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -14,6 +14,8 @@ const prefixRegex = /^[A-Z0-9]+$/; // Only uppercase letters and digits, no hyph
 const baseSectionSchema = z.object({
   name: z.string(req('Tên khu vực là bắt buộc')).min(1, 'Tên khu vực không được trống'),
 
+  type: z.enum(['assigned', 'general']).default('assigned'),
+
   prefix: z
     .string(req('Mã tiền tố là bắt buộc'))
     .transform((v) => v.trim().toUpperCase())
@@ -24,6 +26,8 @@ const baseSectionSchema = z.object({
         .max(10, 'Mã tiền tố tối đa 10 ký tự')
         .regex(prefixRegex, 'Mã tiền tố chỉ được chứa chữ in hoa và số (A-Z, 0-9)'),
     ),
+
+  is_seat_pickable: z.boolean().default(true),
 
   rows: z
     .number(req('Số hàng là bắt buộc'))
@@ -170,7 +174,9 @@ export type SectionFormData = Omit<SectionInput, 'disabled_seats'> & { disabled_
 // ── Draft persistence schema (validates shape/types only, not business rules) ──
 const sectionFormDraftSchema = z.object({
   name: z.string(),
+  type: z.enum(['assigned', 'general']),
   prefix: z.string(),
+  is_seat_pickable: z.boolean(),
   price: z.number(),
   rows: z.number().int(),
   cols: z.number().int(),


### PR DESCRIPTION
## Mô tả

Cập nhật schema database để hỗ trợ để hỗ trợ custom sân khấu và hệ thống vé đứng.

Closes #61

## Loại thay đổi

- [x] ✨ Feature mới
- [x] 💄 UI / Style

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event status now includes sold out, completed, and cancelled states
  * Events can enforce age restrictions and per-user ticket purchase limits
  * Added stage layout configuration for events
  * Seat sections now support customizable types (assigned/general) and seat-pickability
  * Check-in tracking for attendees (checked-in flag and timestamp)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->