### PR TITLE
feat(event): refactor event service to support shows and their sections

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,5 +1,5 @@
 // src/lib/server/db/schema.ts
-import { sql } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import {
   boolean,
   check,
@@ -21,16 +21,29 @@ import {
 export const roleEnum = pgEnum('role', ['admin', 'customer']);
 export const genderEnum = pgEnum('gender', ['male', 'female', 'other']);
 
+// NOTE: "sold_out" is intentionally excluded — it is a derived/computed state
+// calculated at the application layer (when available_seats === 0).
 export const eventStatusEnum = pgEnum('event_status', [
   'draft',
   'published',
-  'sold_out',
   'completed',
   'cancelled',
 ]);
+
+export const showStatusEnum = pgEnum('show_status', [
+  'draft',
+  'published',
+  'completed',
+  'cancelled',
+]);
+
 export const seatStatusEnum = pgEnum('seat_status', ['available', 'locked', 'sold', 'disabled']);
 export const seatTypeEnum = pgEnum('seat_type', ['assigned', 'general']);
 export const orderStatusEnum = pgEnum('order_status', ['pending', 'paid', 'cancelled']);
+
+// ══════════════════════════════════════════════════
+// TABLES
+// ══════════════════════════════════════════════════
 
 // ── Users ──────────────────────────────────────
 export const users = pgTable('users', {
@@ -45,40 +58,101 @@ export const users = pgTable('users', {
   role: roleEnum('role').notNull().default('customer'),
   isActive: boolean('is_active').notNull().default(true),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
 });
 
-// ── Events ─────────────────────────────────────
+// ── Events (General Info — dates live on event_shows) ──────
 export const events = pgTable(
   'events',
   {
     id: serial('id').primaryKey(),
     title: varchar('title', { length: 200 }).notNull(),
-    description: text('description').notNull(),
+    description: text('description').notNull(), // Markdown supported
+    termsAndConditions: text('terms_and_conditions'), // Markdown supported
     venue: varchar('venue', { length: 200 }).notNull(),
-    eventDate: timestamp('event_date', { withTimezone: true }).notNull(),
     bannerImageUrl: varchar('banner_image_url', { length: 500 }),
-    minAge: integer('min_age').notNull().default(0), // 0 là mọi lứa tuổi
-    maxTicketsPerUser: integer('max_tickets_per_user').notNull().default(0), // 0 là không giới hạn
+    staticMapImageUrl: varchar('static_map_image_url', { length: 500 }),
+    minAge: integer('min_age').notNull().default(0), // 0 = all ages
+    maxTicketsPerUser: integer('max_tickets_per_user').notNull().default(0), // 0 = unlimited
+
     stageLayout: jsonb('stage_layout').default([]),
-    /* Ví dụ data bên trong:
+    /* Example stageLayout:
        [
          { "id": "main", "label": "Sân khấu chính", "type": "rect", "x": 10, "y": 0, "w": 20, "h": 5 },
-         { "id": "catwalk", "label": "Đường băng", "type": "rect", "x": 18, "y": 5, "w": 4, "h": 10 },
-         { "id": "center", "label": "Center Stage", "type": "circle", "x": 20, "y": 20, "radius": 8 }
+         { "id": "catwalk", "label": "Đường băng", "type": "rect", "x": 18, "y": 5, "w": 4, "h": 10 }
        ]
+    */
+
+    amenities: text('amenities')
+      .array()
+      .notNull()
+      .default(sql`'{}'::text[]`),
+
+    organizerInfo: jsonb('organizer_info').default({}),
+    /* Example organizerInfo:
+       {
+         "name": "TixTac Entertainment",
+         "email": "contact@tixtac.io.vn",
+         "phone": "+84 28 1234 5678",
+         "website": "https://tixtac.io.vn"
+       }
     */
 
     status: eventStatusEnum('status').notNull().default('draft'),
     createdBy: integer('created_by')
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, { onDelete: 'restrict' }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
   },
   (table) => [
     check('chk_min_age_non_negative', sql`${table.minAge} >= 0`),
     check('chk_max_tickets_per_user_non_negative', sql`${table.maxTicketsPerUser} >= 0`),
+  ],
+);
+
+// ── Event Shows (Sessions / Performances) ──────
+export const eventShows = pgTable(
+  'event_shows',
+  {
+    id: serial('id').primaryKey(),
+    eventId: integer('event_id')
+      .notNull()
+      .references(() => events.id, { onDelete: 'cascade' }),
+    title: varchar('title', { length: 200 }), // e.g. "Day 1 — Opening Night"
+    showDate: date('show_date').notNull(),
+    startTime: timestamp('start_time', { withTimezone: true }).notNull(),
+    endTime: timestamp('end_time', { withTimezone: true }),
+
+    itinerary: jsonb('itinerary').default([]),
+    /* Example itinerary:
+       [
+         { "time": "18:00", "activity": "Mở cửa", "description": "Check-in và nhận vòng tay" },
+         { "time": "19:00", "activity": "DJ Warm-up", "description": "" },
+         { "time": "20:00", "activity": "Main Act", "description": "Nghệ sĩ chính biểu diễn" },
+         { "time": "22:30", "activity": "Kết thúc", "description": "" }
+       ]
+    */
+
+    status: showStatusEnum('status').notNull().default('draft'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    index('idx_event_shows_event').on(table.eventId),
+    check(
+      'chk_show_end_after_start',
+      sql`${table.endTime} IS NULL OR ${table.endTime} > ${table.startTime}`,
+    ),
   ],
 );
 
@@ -87,24 +161,37 @@ export const seatSections = pgTable(
   'seat_sections',
   {
     id: serial('id').primaryKey(),
-    eventId: integer('event_id')
+    showId: integer('show_id')
       .notNull()
-      .references(() => events.id),
+      .references(() => eventShows.id, { onDelete: 'cascade' }),
     name: varchar('name', { length: 50 }).notNull(),
     type: seatTypeEnum('type').notNull().default('assigned'),
     prefix: varchar('prefix', { length: 10 }).notNull(),
     isSeatPickable: boolean('is_pickable').notNull().default(true),
-    rows: integer('rows').notNull(),
-    cols: integer('cols').notNull(),
+    rows: integer('rows').notNull().default(0),
+    cols: integer('cols').notNull().default(0),
+    capacity: integer('capacity').notNull().default(0), // For general admission sections
     price: decimal('price', { precision: 12, scale: 2 }).notNull(),
     layoutX: integer('layout_x').notNull().default(0),
     layoutY: integer('layout_y').notNull().default(0),
     startRowIndex: integer('start_row_index').notNull().default(0),
     startColIndex: integer('start_col_index').notNull().default(1),
     sortOrder: integer('sort_order').notNull().default(0),
+
+    visualLayout: jsonb('visual_layout').default([]),
+    /* Example visualLayout — coordinates for rendering on interactive map:
+       [
+         { "x": 10, "y": 20, "w": 50, "h": 30, "label": "Khu VIP Trái" },
+         { "x": 70, "y": 20, "w": 50, "h": 30, "label": "Khu VIP Phải" }
+       ]
+    */
+
+    salesStartAt: timestamp('sales_start_at', { withTimezone: true }),
+    salesEndAt: timestamp('sales_end_at', { withTimezone: true }),
+
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index('idx_seat_sections_event').on(table.eventId)],
+  (table) => [index('idx_seat_sections_show').on(table.showId)],
 );
 
 // ── Seats ──────────────────────────────────────
@@ -114,46 +201,46 @@ export const seats = pgTable(
     id: serial('id').primaryKey(),
     sectionId: integer('section_id')
       .notNull()
-      .references(() => seatSections.id),
-    eventId: integer('event_id')
+      .references(() => seatSections.id, { onDelete: 'cascade' }),
+    showId: integer('show_id')
       .notNull()
-      .references(() => events.id),
+      .references(() => eventShows.id, { onDelete: 'cascade' }),
     prefix: varchar('prefix', { length: 10 }).notNull(),
     rowLabel: varchar('row_label', { length: 5 }).notNull(),
     colNumber: integer('col_number').notNull(),
     status: seatStatusEnum('status').notNull().default('available'),
-    lockedBy: integer('locked_by').references(() => users.id),
+    lockedBy: integer('locked_by').references(() => users.id, { onDelete: 'set null' }),
     lockedAt: timestamp('locked_at', { withTimezone: true }),
   },
   (table) => [
-    uniqueIndex('uq_seat_label_per_event').on(
-      table.eventId,
+    uniqueIndex('uq_seat_label_per_show').on(
+      table.showId,
       table.prefix,
       table.rowLabel,
       table.colNumber,
     ),
-    index('idx_seats_event_status').on(table.eventId, table.status),
+    index('idx_seats_show_status').on(table.showId, table.status),
     index('idx_seats_section').on(table.sectionId),
   ],
 );
 
-// ── Orders ─────────────────────────────────────
+// ── Orders (Cart — can span multiple shows) ────
 export const orders = pgTable(
   'orders',
   {
     id: serial('id').primaryKey(),
     userId: integer('user_id')
       .notNull()
-      .references(() => users.id),
-    eventId: integer('event_id')
-      .notNull()
-      .references(() => events.id),
+      .references(() => users.id, { onDelete: 'restrict' }),
     totalAmount: decimal('total_amount', { precision: 12, scale: 2 }).notNull(),
     status: orderStatusEnum('status').notNull().default('pending'),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     paidAt: timestamp('paid_at', { withTimezone: true }),
-    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
   },
   (table) => [
     index('idx_orders_user').on(table.userId, table.status),
@@ -170,21 +257,93 @@ export const orderItems = pgTable(
     id: serial('id').primaryKey(),
     orderId: integer('order_id')
       .notNull()
-      .references(() => orders.id),
+      .references(() => orders.id, { onDelete: 'cascade' }),
     seatId: integer('seat_id')
       .notNull()
-      .references(() => seats.id),
+      .references(() => seats.id, { onDelete: 'restrict' }),
     priceSnapshot: decimal('price_snapshot', { precision: 12, scale: 2 }).notNull(),
+
+    ticketCode: varchar('ticket_code', { length: 20 }).notNull().unique(),
+    /* Unique human-readable code for manual check-in, e.g. "TIX-A3F8K2" */
+
     qrCode: text('qr_code'),
     isCheckedIn: boolean('is_checked_in').notNull().default(false),
     checkedInAt: timestamp('checked_in_at', { withTimezone: true }),
-
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
+    uniqueIndex('uq_ticket_code').on(table.ticketCode),
     check(
       'chk_checked_in_consistency',
       sql`${table.isCheckedIn} = (${table.checkedInAt} IS NOT NULL)`,
     ),
   ],
 );
+
+// ══════════════════════════════════════════════════
+// RELATIONS (Drizzle Query Builder / N+1 prevention)
+// ══════════════════════════════════════════════════
+
+export const usersRelations = relations(users, ({ many }) => ({
+  createdEvents: many(events),
+  orders: many(orders),
+}));
+
+export const eventsRelations = relations(events, ({ one, many }) => ({
+  createdByUser: one(users, {
+    fields: [events.createdBy],
+    references: [users.id],
+  }),
+  shows: many(eventShows),
+}));
+
+export const eventShowsRelations = relations(eventShows, ({ one, many }) => ({
+  event: one(events, {
+    fields: [eventShows.eventId],
+    references: [events.id],
+  }),
+  sections: many(seatSections),
+  seats: many(seats),
+}));
+
+export const seatSectionsRelations = relations(seatSections, ({ one, many }) => ({
+  show: one(eventShows, {
+    fields: [seatSections.showId],
+    references: [eventShows.id],
+  }),
+  seats: many(seats),
+}));
+
+export const seatsRelations = relations(seats, ({ one }) => ({
+  section: one(seatSections, {
+    fields: [seats.sectionId],
+    references: [seatSections.id],
+  }),
+  show: one(eventShows, {
+    fields: [seats.showId],
+    references: [eventShows.id],
+  }),
+  lockedByUser: one(users, {
+    fields: [seats.lockedBy],
+    references: [users.id],
+  }),
+}));
+
+export const ordersRelations = relations(orders, ({ one, many }) => ({
+  user: one(users, {
+    fields: [orders.userId],
+    references: [users.id],
+  }),
+  items: many(orderItems),
+}));
+
+export const orderItemsRelations = relations(orderItems, ({ one }) => ({
+  order: one(orders, {
+    fields: [orderItems.orderId],
+    references: [orders.id],
+  }),
+  seat: one(seats, {
+    fields: [orderItems.seatId],
+    references: [seats.id],
+  }),
+}));

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -938,7 +938,7 @@ export async function seed() {
   console.log('');
   console.log('✅ Seed completed!');
   console.log('  Events: 6 (5 published, 1 draft)');
-  console.log('  Shows: 9 total (2+1+1+1+2+1 = 8 shows, Events 1 & 5 have 2 days each)');
+  console.log('  Shows: 8 total (2+1+1+1+2+1 = 8 shows, Events 1 & 5 have 2 days each)');
   console.log('  Users: 1 admin + 10 customers');
 }
 

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -1,6 +1,14 @@
 // src/lib/server/db/seed.ts
 import { db } from '$lib/server/db';
-import { events, orderItems, orders, seatSections, seats, users } from '$lib/server/db/schema';
+import {
+  events,
+  eventShows,
+  orderItems,
+  orders,
+  seats,
+  seatSections,
+  users,
+} from '$lib/server/db/schema';
 import * as argon2 from 'argon2';
 import { eq } from 'drizzle-orm';
 
@@ -109,6 +117,7 @@ interface SectionSeed {
   isSeatPickable: boolean;
   rows: number;
   cols: number;
+  capacity: number;
   price: string;
   layoutX: number;
   layoutY: number;
@@ -116,42 +125,73 @@ interface SectionSeed {
   startColIndex: number;
   sortOrder: number;
   disabledSeats?: string[];
+  salesStartAt?: Date;
+  salesEndAt?: Date;
+}
+
+interface ShowSeed {
+  title?: string | null;
+  showDate: string;
+  startTime: Date;
+  endTime?: Date;
+  itinerary?: { time: string; activity: string; description: string }[];
+  status: 'draft' | 'published' | 'completed' | 'cancelled';
+  sections: SectionSeed[];
 }
 
 // ── Seat generation ────────────────────────────
 
-async function createSections(eventId: number, sections: SectionSeed[]) {
-  for (const s of sections) {
+async function createShowWithSections(eventId: number, show: ShowSeed) {
+  const [newShow] = await db
+    .insert(eventShows)
+    .values({
+      eventId,
+      title: show.title || null,
+      showDate: show.showDate,
+      startTime: show.startTime,
+      endTime: show.endTime || null,
+      itinerary: show.itinerary ?? [],
+      status: show.status,
+    })
+    .returning();
+
+  for (const s of show.sections) {
     const [section] = await db
       .insert(seatSections)
       .values({
-        eventId,
+        showId: newShow.id,
         name: s.name,
         prefix: s.prefix,
         type: s.type,
         isSeatPickable: s.isSeatPickable,
         rows: s.rows,
         cols: s.cols,
+        capacity: s.capacity,
         price: s.price,
         layoutX: s.layoutX,
         layoutY: s.layoutY,
         startRowIndex: s.startRowIndex,
         startColIndex: s.startColIndex,
         sortOrder: s.sortOrder,
+        salesStartAt: s.salesStartAt || null,
+        salesEndAt: s.salesEndAt || null,
       })
       .returning();
 
     const disabledSet = new Set(s.disabledSeats ?? []);
+    const isGA = s.type === 'general';
+    const effectiveRows = isGA ? s.capacity : s.rows;
+    const effectiveCols = isGA ? 1 : s.cols;
     const seatValues = [];
 
-    for (let r = 0; r < s.rows; r++) {
-      const rowLabel = getRowLabel(s.startRowIndex + r);
-      for (let c = 0; c < s.cols; c++) {
-        const colNumber = s.startColIndex + c;
-        const label = `${s.prefix}-${rowLabel}${colNumber}`;
+    for (let r = 0; r < effectiveRows; r++) {
+      const rowLabel = isGA ? '' : getRowLabel(s.startRowIndex + r);
+      for (let c = 0; c < effectiveCols; c++) {
+        const colNumber = isGA ? r + 1 : s.startColIndex + c;
+        const label = isGA ? `${s.prefix}-${r + 1}` : `${s.prefix}-${rowLabel}${colNumber}`;
         seatValues.push({
           sectionId: section.id,
-          eventId,
+          showId: newShow.id,
           prefix: s.prefix,
           rowLabel,
           colNumber,
@@ -164,6 +204,8 @@ async function createSections(eventId: number, sections: SectionSeed[]) {
       await db.insert(seats).values(seatValues.slice(i, i + 1000));
     }
   }
+
+  return newShow;
 }
 
 // ══════════════════════════════════════════════════
@@ -179,6 +221,7 @@ export async function seed() {
   await db.delete(orders);
   await db.delete(seats);
   await db.delete(seatSections);
+  await db.delete(eventShows);
   await db.delete(events);
 
   // ── 2. Admin — upsert (skip if exists) ──
@@ -222,26 +265,45 @@ export async function seed() {
   console.log('👥 10 random customers seeded');
 
   // ══════════════════════════════════════════════
-  // EVENT 1 — Rock Festival · Stadium · Published
-  // Assigned pickable VIP split L/R + Standard + GA standing
+  // EVENT 1 — Rock Festival 2026 · 2-Day Multi-Show · Published
+  // Day 1 & Day 2 with independent seating
   // ══════════════════════════════════════════════
   const [ev1] = await db
     .insert(events)
     .values({
       title: 'Rock Festival 2026',
-      description: 'Đại nhạc hội rock lớn nhất năm với sự tham gia của các ban nhạc hàng đầu.',
+      description:
+        '## Đại nhạc hội Rock lớn nhất năm\n\n' +
+        'Với sự tham gia của **các ban nhạc hàng đầu** Việt Nam và quốc tế.\n\n' +
+        '### Highlights\n' +
+        '- 2 đêm diễn liên tiếp\n' +
+        '- Hơn 20 nghệ sĩ\n' +
+        '- Sân khấu hoành tráng\n',
+      termsAndConditions:
+        '## Điều khoản tham dự\n\n' +
+        '1. Vé đã mua **không hoàn, không đổi**.\n' +
+        '2. Ban tổ chức có quyền từ chối phục vụ người sử dụng chất kích thích.\n' +
+        '3. Trẻ em dưới 16 tuổi phải có người giám hộ đi kèm.\n',
       venue: 'Sân vận động Mỹ Đình, Hà Nội',
-      eventDate: new Date('2026-06-15T19:00:00+07:00'),
       bannerImageUrl: 'https://picsum.photos/seed/rock/800/400',
+      staticMapImageUrl: null,
       minAge: 16,
       maxTicketsPerUser: 4,
       stageLayout: [{ id: 'main', label: 'Main Stage', type: 'rect', x: 5, y: 0, w: 20, h: 4 }],
+      amenities: ['parking', 'wifi', 'f-and-b', 'restroom', 'first-aid'],
+      organizerInfo: {
+        name: 'TixTac Entertainment',
+        email: 'contact@tixtac.io.vn',
+        phone: '+84 28 1234 5678',
+        website: 'https://tixtac.io.vn',
+      },
       status: 'published',
       createdBy: admin.id,
     })
     .returning();
 
-  await createSections(ev1.id, [
+  // Day 1 sections
+  const day1Sections: SectionSeed[] = [
     {
       name: 'VIP - Trái',
       prefix: 'VIPL',
@@ -249,6 +311,7 @@ export async function seed() {
       isSeatPickable: true,
       rows: 5,
       cols: 10,
+      capacity: 0,
       price: '2000000',
       layoutX: 0,
       layoutY: 6,
@@ -263,6 +326,7 @@ export async function seed() {
       isSeatPickable: true,
       rows: 5,
       cols: 10,
+      capacity: 0,
       price: '2000000',
       layoutX: 15,
       layoutY: 6,
@@ -277,6 +341,7 @@ export async function seed() {
       isSeatPickable: true,
       rows: 15,
       cols: 30,
+      capacity: 0,
       price: '500000',
       layoutX: 0,
       layoutY: 12,
@@ -289,8 +354,9 @@ export async function seed() {
       prefix: 'GA',
       type: 'general',
       isSeatPickable: false,
-      rows: 200,
-      cols: 1,
+      rows: 0,
+      cols: 0,
+      capacity: 200,
       price: '300000',
       layoutX: 0,
       layoutY: 28,
@@ -298,21 +364,58 @@ export async function seed() {
       startColIndex: 1,
       sortOrder: 3,
     },
-  ]);
+  ];
 
-  console.log(`🎸 Event 1: "${ev1.title}" — VIP L/R + Standard + GA`);
+  await createShowWithSections(ev1.id, {
+    title: 'Day 1 — Opening Night',
+    showDate: '2026-06-15',
+    startTime: new Date('2026-06-15T19:00:00+07:00'),
+    endTime: new Date('2026-06-15T23:00:00+07:00'),
+    itinerary: [
+      { time: '18:00', activity: 'Mở cửa', description: 'Check-in và nhận vòng tay' },
+      { time: '19:00', activity: 'DJ Warm-up', description: 'DJ khách mời' },
+      { time: '20:00', activity: 'Band 1', description: 'Ngọt' },
+      { time: '21:00', activity: 'Band 2', description: 'Cá Hồi Hoang' },
+      { time: '22:00', activity: 'Headliner', description: 'Đen Vâu' },
+      { time: '23:00', activity: 'Kết thúc', description: '' },
+    ],
+    status: 'published',
+    sections: day1Sections,
+  });
+
+  // Day 2 sections (same layout, cloned)
+  await createShowWithSections(ev1.id, {
+    title: 'Day 2 — Grand Finale',
+    showDate: '2026-06-16',
+    startTime: new Date('2026-06-16T19:00:00+07:00'),
+    endTime: new Date('2026-06-16T23:30:00+07:00'),
+    itinerary: [
+      { time: '18:00', activity: 'Mở cửa', description: 'Check-in và nhận vòng tay' },
+      { time: '19:00', activity: 'DJ Set', description: 'DJ Hoaprox' },
+      { time: '20:00', activity: 'Band 3', description: 'Chillies' },
+      { time: '21:00', activity: 'Band 4', description: 'Da LAB' },
+      { time: '22:00', activity: 'Grand Finale', description: 'Sơn Tùng M-TP' },
+      { time: '23:30', activity: 'Kết thúc', description: '' },
+    ],
+    status: 'published',
+    sections: day1Sections,
+  });
+
+  console.log(`🎸 Event 1: "${ev1.title}" — 2-day festival, VIP L/R + Standard + GA`);
 
   // ══════════════════════════════════════════════
-  // EVENT 2 — EDM Night · Arena · Published
+  // EVENT 2 — EDM Night · Arena · Published · Single Show
   // Assigned pickable Diamond/Gold/Silver + disabled seats
   // ══════════════════════════════════════════════
   const [ev2] = await db
     .insert(events)
     .values({
       title: 'EDM Night Saigon',
-      description: 'Đêm nhạc điện tử sôi động nhất TP.HCM với DJ quốc tế.',
+      description:
+        '## Đêm nhạc điện tử sôi động nhất TP.HCM\n\n' +
+        'Với sự góp mặt của **DJ quốc tế** và dàn âm thanh *đỉnh cao*.\n',
+      termsAndConditions: null,
       venue: 'Nhà thi đấu Phú Thọ, TP.HCM',
-      eventDate: new Date('2026-07-20T20:00:00+07:00'),
       bannerImageUrl: 'https://picsum.photos/seed/edm/800/400',
       minAge: 18,
       maxTicketsPerUser: 6,
@@ -320,57 +423,78 @@ export async function seed() {
         { id: 'main', label: 'DJ Booth', type: 'rect', x: 8, y: 0, w: 14, h: 3 },
         { id: 'catwalk', label: 'Catwalk', type: 'rect', x: 14, y: 3, w: 2, h: 8 },
       ],
+      amenities: ['parking', 'f-and-b', 'restroom'],
+      organizerInfo: {
+        name: 'Ravolution Music',
+        email: 'info@ravolution.vn',
+      },
       status: 'published',
       createdBy: admin.id,
     })
     .returning();
 
-  await createSections(ev2.id, [
-    {
-      name: 'Diamond',
-      prefix: 'DIA',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 3,
-      cols: 15,
-      price: '3000000',
-      layoutX: 0,
-      layoutY: 5,
-      startRowIndex: 0,
-      startColIndex: 1,
-      sortOrder: 0,
-      disabledSeats: ['DIA-B8', 'DIA-C8'],
-    },
-    {
-      name: 'Gold',
-      prefix: 'GOLD',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 5,
-      cols: 20,
-      price: '1500000',
-      layoutX: 0,
-      layoutY: 9,
-      startRowIndex: 3,
-      startColIndex: 1,
-      sortOrder: 1,
-    },
-    {
-      name: 'Silver',
-      prefix: 'SIL',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 10,
-      cols: 25,
-      price: '700000',
-      layoutX: 0,
-      layoutY: 15,
-      startRowIndex: 8,
-      startColIndex: 1,
-      sortOrder: 2,
-      disabledSeats: ['SIL-I13', 'SIL-J13', 'SIL-K13'],
-    },
-  ]);
+  await createShowWithSections(ev2.id, {
+    title: null,
+    showDate: '2026-07-20',
+    startTime: new Date('2026-07-20T20:00:00+07:00'),
+    endTime: new Date('2026-07-21T02:00:00+07:00'),
+    itinerary: [
+      { time: '19:00', activity: 'Mở cửa', description: '' },
+      { time: '20:00', activity: 'DJ Set 1', description: 'Local DJs' },
+      { time: '22:00', activity: 'Main Act', description: 'DJ quốc tế' },
+      { time: '01:00', activity: 'Closing Set', description: '' },
+    ],
+    status: 'published',
+    sections: [
+      {
+        name: 'Diamond',
+        prefix: 'DIA',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 3,
+        cols: 15,
+        capacity: 0,
+        price: '3000000',
+        layoutX: 0,
+        layoutY: 5,
+        startRowIndex: 0,
+        startColIndex: 1,
+        sortOrder: 0,
+        disabledSeats: ['DIA-B8', 'DIA-C8'],
+      },
+      {
+        name: 'Gold',
+        prefix: 'GOLD',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 5,
+        cols: 20,
+        capacity: 0,
+        price: '1500000',
+        layoutX: 0,
+        layoutY: 9,
+        startRowIndex: 3,
+        startColIndex: 1,
+        sortOrder: 1,
+      },
+      {
+        name: 'Silver',
+        prefix: 'SIL',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 10,
+        cols: 25,
+        capacity: 0,
+        price: '700000',
+        layoutX: 0,
+        layoutY: 15,
+        startRowIndex: 8,
+        startColIndex: 1,
+        sortOrder: 2,
+        disabledSeats: ['SIL-I13', 'SIL-J13', 'SIL-K13'],
+      },
+    ],
+  });
 
   console.log(`🎧 Event 2: "${ev2.title}" — Diamond/Gold/Silver with disabled seats`);
 
@@ -383,48 +507,57 @@ export async function seed() {
     .values({
       title: 'Acoustic Intimate Night',
       description:
-        'Đêm nhạc acoustic ấm cúng với các nghệ sĩ indie nổi tiếng. Ghế được hệ thống tự phân bổ theo thứ tự.',
+        '## Đêm nhạc acoustic ấm cúng\n\n' +
+        'Với các nghệ sĩ indie nổi tiếng. Ghế được hệ thống **tự phân bổ** theo thứ tự.\n',
       venue: 'Nhà hát nhỏ, 22 Hai Bà Trưng, Hà Nội',
-      eventDate: new Date('2026-08-10T19:30:00+07:00'),
       bannerImageUrl: 'https://picsum.photos/seed/acoustic/800/400',
       minAge: 0,
       maxTicketsPerUser: 2,
       stageLayout: [{ id: 'stage', label: 'Sân khấu', type: 'rect', x: 2, y: 0, w: 8, h: 3 }],
+      amenities: ['wifi', 'f-and-b'],
       status: 'published',
       createdBy: admin.id,
     })
     .returning();
 
-  await createSections(ev3.id, [
-    {
-      name: 'Premium',
-      prefix: 'PRM',
-      type: 'assigned',
-      isSeatPickable: false,
-      rows: 5,
-      cols: 12,
-      price: '800000',
-      layoutX: 0,
-      layoutY: 4,
-      startRowIndex: 0,
-      startColIndex: 1,
-      sortOrder: 0,
-    },
-    {
-      name: 'Regular',
-      prefix: 'REG',
-      type: 'assigned',
-      isSeatPickable: false,
-      rows: 8,
-      cols: 12,
-      price: '400000',
-      layoutX: 0,
-      layoutY: 10,
-      startRowIndex: 5,
-      startColIndex: 1,
-      sortOrder: 1,
-    },
-  ]);
+  await createShowWithSections(ev3.id, {
+    showDate: '2026-08-10',
+    startTime: new Date('2026-08-10T19:30:00+07:00'),
+    endTime: new Date('2026-08-10T22:00:00+07:00'),
+    status: 'published',
+    sections: [
+      {
+        name: 'Premium',
+        prefix: 'PRM',
+        type: 'assigned',
+        isSeatPickable: false,
+        rows: 5,
+        cols: 12,
+        capacity: 0,
+        price: '800000',
+        layoutX: 0,
+        layoutY: 4,
+        startRowIndex: 0,
+        startColIndex: 1,
+        sortOrder: 0,
+      },
+      {
+        name: 'Regular',
+        prefix: 'REG',
+        type: 'assigned',
+        isSeatPickable: false,
+        rows: 8,
+        cols: 12,
+        capacity: 0,
+        price: '400000',
+        layoutX: 0,
+        layoutY: 10,
+        startRowIndex: 5,
+        startColIndex: 1,
+        sortOrder: 1,
+      },
+    ],
+  });
 
   console.log(`🎵 Event 3: "${ev3.title}" — Non-pickable assigned seating`);
 
@@ -437,93 +570,122 @@ export async function seed() {
     .values({
       title: 'Stand-Up Comedy Night',
       description:
-        'Đêm hài kịch đứng với 5 nghệ sĩ hài nổi tiếng. Sân khấu vòng tròn giữa khán phòng.',
+        '## Đêm hài kịch đứng\n\n' +
+        'Với **5 nghệ sĩ hài** nổi tiếng. Sân khấu vòng tròn giữa khán phòng.\n',
       venue: 'Galaxy Cinema Nguyễn Du, TP.HCM',
-      eventDate: new Date('2026-09-05T20:00:00+07:00'),
       bannerImageUrl: 'https://picsum.photos/seed/comedy/800/400',
       minAge: 16,
       maxTicketsPerUser: 4,
       stageLayout: [
         { id: 'center', label: 'Center Stage', type: 'circle', x: 12, y: 12, radius: 3 },
       ],
+      amenities: ['parking', 'f-and-b', 'restroom'],
       status: 'published',
       createdBy: admin.id,
     })
     .returning();
 
-  await createSections(ev4.id, [
-    {
-      name: 'Front Row',
-      prefix: 'FR',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 3,
-      cols: 20,
-      price: '1200000',
-      layoutX: 0,
-      layoutY: 0,
-      startRowIndex: 0,
-      startColIndex: 1,
-      sortOrder: 0,
-    },
-    {
-      name: 'Left Wing',
-      prefix: 'LW',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 8,
-      cols: 8,
-      price: '800000',
-      layoutX: 0,
-      layoutY: 4,
-      startRowIndex: 3,
-      startColIndex: 1,
-      sortOrder: 1,
-    },
-    {
-      name: 'Right Wing',
-      prefix: 'RW',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 8,
-      cols: 8,
-      price: '800000',
-      layoutX: 16,
-      layoutY: 4,
-      startRowIndex: 3,
-      startColIndex: 1,
-      sortOrder: 2,
-    },
-    {
-      name: 'Back',
-      prefix: 'BK',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 5,
-      cols: 20,
-      price: '500000',
-      layoutX: 0,
-      layoutY: 13,
-      startRowIndex: 11,
-      startColIndex: 1,
-      sortOrder: 3,
-    },
-  ]);
+  await createShowWithSections(ev4.id, {
+    showDate: '2026-09-05',
+    startTime: new Date('2026-09-05T20:00:00+07:00'),
+    endTime: new Date('2026-09-05T22:30:00+07:00'),
+    itinerary: [
+      { time: '19:30', activity: 'Mở cửa', description: '' },
+      { time: '20:00', activity: 'MC giới thiệu', description: '' },
+      { time: '20:10', activity: 'Nghệ sĩ 1-3', description: 'Mỗi người 20 phút' },
+      { time: '21:10', activity: 'Giải lao', description: '15 phút' },
+      { time: '21:25', activity: 'Nghệ sĩ 4-5', description: 'Mỗi người 25 phút' },
+      { time: '22:15', activity: 'Q&A', description: '' },
+      { time: '22:30', activity: 'Kết thúc', description: '' },
+    ],
+    status: 'published',
+    sections: [
+      {
+        name: 'Front Row',
+        prefix: 'FR',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 3,
+        cols: 20,
+        capacity: 0,
+        price: '1200000',
+        layoutX: 0,
+        layoutY: 0,
+        startRowIndex: 0,
+        startColIndex: 1,
+        sortOrder: 0,
+      },
+      {
+        name: 'Left Wing',
+        prefix: 'LW',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 8,
+        cols: 8,
+        capacity: 0,
+        price: '800000',
+        layoutX: 0,
+        layoutY: 4,
+        startRowIndex: 3,
+        startColIndex: 1,
+        sortOrder: 1,
+      },
+      {
+        name: 'Right Wing',
+        prefix: 'RW',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 8,
+        cols: 8,
+        capacity: 0,
+        price: '800000',
+        layoutX: 16,
+        layoutY: 4,
+        startRowIndex: 3,
+        startColIndex: 1,
+        sortOrder: 2,
+      },
+      {
+        name: 'Back',
+        prefix: 'BK',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 5,
+        cols: 20,
+        capacity: 0,
+        price: '500000',
+        layoutX: 0,
+        layoutY: 13,
+        startRowIndex: 11,
+        startColIndex: 1,
+        sortOrder: 3,
+      },
+    ],
+  });
 
   console.log(`😂 Event 4: "${ev4.title}" — Circle stage + L-shaped seating`);
 
   // ══════════════════════════════════════════════
   // EVENT 5 — Music Festival · Outdoor · Draft
-  // Multiple stages + all GA (standing only)
+  // Multiple stages + all GA (standing only) + sales timing
   // ══════════════════════════════════════════════
   const [ev5] = await db
     .insert(events)
     .values({
       title: 'Sunset Music Festival 2026',
-      description: 'Festival ngoài trời 2 ngày với 3 sân khấu song song. Tất cả vé đứng tự do.',
+      description:
+        '## Festival ngoài trời 2 ngày\n\n' +
+        'Với **3 sân khấu** song song. Tất cả vé đứng tự do.\n\n' +
+        '### Lưu ý\n' +
+        '- Mang theo nón, kem chống nắng\n' +
+        '- Không mang đồ ăn từ bên ngoài\n',
+      termsAndConditions:
+        '## Điều khoản\n\n' +
+        '1. Vé Early Bird không được đổi sang hạng khác.\n' +
+        '2. Trong trường hợp thời tiết xấu, BTC sẽ thông báo trước 24h.\n',
       venue: 'Bãi biển Mỹ Khê, Đà Nẵng',
-      eventDate: new Date('2026-10-12T15:00:00+07:00'),
       bannerImageUrl: 'https://picsum.photos/seed/sunset/800/400',
+      staticMapImageUrl: 'https://picsum.photos/seed/sunset-map/600/400',
       minAge: 18,
       maxTicketsPerUser: 2,
       stageLayout: [
@@ -531,47 +693,61 @@ export async function seed() {
         { id: 'second', label: 'Second Stage', type: 'rect', x: 25, y: 0, w: 12, h: 4 },
         { id: 'chill', label: 'Chill Zone', type: 'circle', x: 40, y: 5, radius: 5 },
       ],
+      amenities: ['parking', 'wifi', 'f-and-b', 'restroom', 'first-aid', 'atm'],
+      organizerInfo: {
+        name: 'Sunset Events Co.',
+        email: 'hello@sunsetfest.vn',
+        phone: '+84 236 999 8888',
+        website: 'https://sunsetfest.vn',
+      },
       status: 'draft',
       createdBy: admin.id,
     })
     .returning();
 
-  await createSections(ev5.id, [
+  const gaSections: SectionSeed[] = [
     {
       name: 'Early Bird',
       prefix: 'EB',
       type: 'general',
       isSeatPickable: false,
-      rows: 500,
-      cols: 1,
+      rows: 0,
+      cols: 0,
+      capacity: 500,
       price: '800000',
       layoutX: 0,
       layoutY: 6,
       startRowIndex: 0,
       startColIndex: 1,
       sortOrder: 0,
+      salesStartAt: new Date('2026-06-01T00:00:00+07:00'),
+      salesEndAt: new Date('2026-07-31T23:59:59+07:00'),
     },
     {
       name: 'Regular',
       prefix: 'RG',
       type: 'general',
       isSeatPickable: false,
-      rows: 1500,
-      cols: 1,
+      rows: 0,
+      cols: 0,
+      capacity: 1500,
       price: '1200000',
       layoutX: 0,
       layoutY: 7,
       startRowIndex: 0,
       startColIndex: 1,
       sortOrder: 1,
+      salesStartAt: new Date('2026-08-01T00:00:00+07:00'),
+      salesEndAt: new Date('2026-10-11T23:59:59+07:00'),
     },
     {
       name: 'VIP Lounge',
       prefix: 'VIPL',
       type: 'general',
       isSeatPickable: false,
-      rows: 100,
-      cols: 1,
+      rows: 0,
+      cols: 0,
+      capacity: 100,
       price: '3500000',
       layoutX: 0,
       layoutY: 8,
@@ -579,21 +755,56 @@ export async function seed() {
       startColIndex: 1,
       sortOrder: 2,
     },
-  ]);
+  ];
 
-  console.log(`🌅 Event 5: "${ev5.title}" — All-GA outdoor festival (draft)`);
+  await createShowWithSections(ev5.id, {
+    title: 'Day 1 — Sunset Sessions',
+    showDate: '2026-10-12',
+    startTime: new Date('2026-10-12T15:00:00+07:00'),
+    endTime: new Date('2026-10-12T23:00:00+07:00'),
+    itinerary: [
+      { time: '14:00', activity: 'Mở cửa', description: '' },
+      { time: '15:00', activity: 'Warm Up', description: 'Local acts' },
+      { time: '18:00', activity: 'Sunset Set', description: 'DJ hoàng hôn' },
+      { time: '21:00', activity: 'Headliner', description: '' },
+      { time: '23:00', activity: 'Kết thúc Day 1', description: '' },
+    ],
+    status: 'draft',
+    sections: gaSections,
+  });
+
+  await createShowWithSections(ev5.id, {
+    title: 'Day 2 — Grand Finale',
+    showDate: '2026-10-13',
+    startTime: new Date('2026-10-13T15:00:00+07:00'),
+    endTime: new Date('2026-10-13T23:30:00+07:00'),
+    itinerary: [
+      { time: '14:00', activity: 'Mở cửa', description: '' },
+      { time: '15:00', activity: 'Warm Up', description: '' },
+      { time: '18:00', activity: 'Special Guest', description: '' },
+      { time: '21:00', activity: 'Grand Finale Set', description: '' },
+      { time: '23:30', activity: 'Kết thúc Festival', description: '' },
+    ],
+    status: 'draft',
+    sections: gaSections,
+  });
+
+  console.log(
+    `🌅 Event 5: "${ev5.title}" — 2-day all-GA outdoor festival (draft) with sales timing`,
+  );
 
   // ══════════════════════════════════════════════
   // EVENT 6 — K-Pop Concert · Large arena · Published
-  // Runway stage + mixed assigned/GA
+  // Runway stage + mixed assigned/GA · Single show
   // ══════════════════════════════════════════════
   const [ev6] = await db
     .insert(events)
     .values({
       title: 'K-Pop Super Live 2026',
-      description: 'Đêm nhạc K-Pop hoành tráng với sân khấu đường băng xuyên giữa khán đài.',
+      description:
+        '## Đêm nhạc K-Pop hoành tráng\n\n' +
+        'Sân khấu đường băng xuyên giữa khán đài. **Lần đầu tiên** tại Việt Nam!\n',
       venue: 'Trung tâm Hội nghị Quốc gia, Hà Nội',
-      eventDate: new Date('2026-11-22T18:00:00+07:00'),
       bannerImageUrl: 'https://picsum.photos/seed/kpop/800/400',
       minAge: 0,
       maxTicketsPerUser: 4,
@@ -602,97 +813,124 @@ export async function seed() {
         { id: 'runway', label: 'Runway', type: 'rect', x: 18, y: 5, w: 4, h: 15 },
         { id: 'bstage', label: 'B-Stage', type: 'circle', x: 20, y: 22, radius: 4 },
       ],
+      amenities: ['parking', 'wifi', 'f-and-b', 'restroom', 'merch-booth'],
+      organizerInfo: {
+        name: 'K-Entertainment VN',
+        email: 'kpop@entertainment.vn',
+      },
       status: 'published',
       createdBy: admin.id,
     })
     .returning();
 
-  await createSections(ev6.id, [
-    {
-      name: 'VVIP',
-      prefix: 'VVIP',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 3,
-      cols: 15,
-      price: '5000000',
-      layoutX: 0,
-      layoutY: 6,
-      startRowIndex: 0,
-      startColIndex: 1,
-      sortOrder: 0,
-    },
-    {
-      name: 'VIP - Left',
-      prefix: 'VL',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 8,
-      cols: 15,
-      price: '3000000',
-      layoutX: 0,
-      layoutY: 10,
-      startRowIndex: 3,
-      startColIndex: 1,
-      sortOrder: 1,
-    },
-    {
-      name: 'VIP - Right',
-      prefix: 'VR',
-      type: 'assigned',
-      isSeatPickable: true,
-      rows: 8,
-      cols: 15,
-      price: '3000000',
-      layoutX: 22,
-      layoutY: 10,
-      startRowIndex: 3,
-      startColIndex: 1,
-      sortOrder: 2,
-    },
-    {
-      name: 'Standard - Left',
-      prefix: 'SL',
-      type: 'assigned',
-      isSeatPickable: false,
-      rows: 12,
-      cols: 20,
-      price: '1500000',
-      layoutX: 0,
-      layoutY: 19,
-      startRowIndex: 11,
-      startColIndex: 1,
-      sortOrder: 3,
-    },
-    {
-      name: 'Standard - Right',
-      prefix: 'SR',
-      type: 'assigned',
-      isSeatPickable: false,
-      rows: 12,
-      cols: 20,
-      price: '1500000',
-      layoutX: 22,
-      layoutY: 19,
-      startRowIndex: 11,
-      startColIndex: 1,
-      sortOrder: 4,
-    },
-    {
-      name: 'GA Floor',
-      prefix: 'GAF',
-      type: 'general',
-      isSeatPickable: false,
-      rows: 500,
-      cols: 1,
-      price: '800000',
-      layoutX: 0,
-      layoutY: 32,
-      startRowIndex: 0,
-      startColIndex: 1,
-      sortOrder: 5,
-    },
-  ]);
+  await createShowWithSections(ev6.id, {
+    showDate: '2026-11-22',
+    startTime: new Date('2026-11-22T18:00:00+07:00'),
+    endTime: new Date('2026-11-22T22:00:00+07:00'),
+    itinerary: [
+      { time: '17:00', activity: 'Mở cửa', description: 'Check-in & nhận lightstick' },
+      { time: '18:00', activity: 'Opening VCR', description: '' },
+      { time: '18:15', activity: 'Performance Block 1', description: '5 bài' },
+      { time: '19:00', activity: 'Talk Session', description: '' },
+      { time: '19:20', activity: 'Performance Block 2', description: '5 bài' },
+      { time: '20:15', activity: 'Game & Fan Interaction', description: '' },
+      { time: '20:45', activity: 'Performance Block 3', description: '5 bài + Encore' },
+      { time: '22:00', activity: 'Ending', description: '' },
+    ],
+    status: 'published',
+    sections: [
+      {
+        name: 'VVIP',
+        prefix: 'VVIP',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 3,
+        cols: 15,
+        capacity: 0,
+        price: '5000000',
+        layoutX: 0,
+        layoutY: 6,
+        startRowIndex: 0,
+        startColIndex: 1,
+        sortOrder: 0,
+      },
+      {
+        name: 'VIP - Left',
+        prefix: 'VL',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 8,
+        cols: 15,
+        capacity: 0,
+        price: '3000000',
+        layoutX: 0,
+        layoutY: 10,
+        startRowIndex: 3,
+        startColIndex: 1,
+        sortOrder: 1,
+      },
+      {
+        name: 'VIP - Right',
+        prefix: 'VR',
+        type: 'assigned',
+        isSeatPickable: true,
+        rows: 8,
+        cols: 15,
+        capacity: 0,
+        price: '3000000',
+        layoutX: 22,
+        layoutY: 10,
+        startRowIndex: 3,
+        startColIndex: 1,
+        sortOrder: 2,
+      },
+      {
+        name: 'Standard - Left',
+        prefix: 'SL',
+        type: 'assigned',
+        isSeatPickable: false,
+        rows: 12,
+        cols: 20,
+        capacity: 0,
+        price: '1500000',
+        layoutX: 0,
+        layoutY: 19,
+        startRowIndex: 11,
+        startColIndex: 1,
+        sortOrder: 3,
+      },
+      {
+        name: 'Standard - Right',
+        prefix: 'SR',
+        type: 'assigned',
+        isSeatPickable: false,
+        rows: 12,
+        cols: 20,
+        capacity: 0,
+        price: '1500000',
+        layoutX: 22,
+        layoutY: 19,
+        startRowIndex: 11,
+        startColIndex: 1,
+        sortOrder: 4,
+      },
+      {
+        name: 'GA Floor',
+        prefix: 'GAF',
+        type: 'general',
+        isSeatPickable: false,
+        rows: 0,
+        cols: 0,
+        capacity: 500,
+        price: '800000',
+        layoutX: 0,
+        layoutY: 32,
+        startRowIndex: 0,
+        startColIndex: 1,
+        sortOrder: 5,
+      },
+    ],
+  });
 
   console.log(`🎤 Event 6: "${ev6.title}" — Runway stage + mixed assigned/GA`);
 
@@ -700,6 +938,7 @@ export async function seed() {
   console.log('');
   console.log('✅ Seed completed!');
   console.log('  Events: 6 (5 published, 1 draft)');
+  console.log('  Shows: 9 total (2+1+1+1+2+1 = 8 shows, Events 1 & 5 have 2 days each)');
   console.log('  Users: 1 admin + 10 customers');
 }
 

--- a/src/lib/server/services/event.service.ts
+++ b/src/lib/server/services/event.service.ts
@@ -1,12 +1,13 @@
 import { db } from '$lib/server/db';
-import { events, seatSections, seats } from '$lib/server/db/schema';
+import { events, eventShows, seats, seatSections } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
 import {
   createEventSchema,
   eventIdSchema,
   eventQuerySchema,
-  updateSectionsSchema,
+  updateShowSectionsSchema,
   type SectionInput,
+  type ShowInput,
 } from '$lib/shared/schemas';
 import { validateInput } from '$lib/shared/validation';
 import { getRowLabel } from '$lib/utils/seat-label';
@@ -15,7 +16,7 @@ import { validateEventRequirements } from '../validators/seat-overlap.validator'
 
 /**
  * Max seats per INSERT statement.
- * Each seat row has 6 columns → 6 params. PG max params = 65535 → ~10k rows.
+ * Each seat row has ~7 columns → ~7 params. PG max params = 65535 → ~9k rows.
  * We use 5000 as a safe, performant batch size.
  */
 export const SEAT_INSERT_BATCH_SIZE = 5000;
@@ -23,7 +24,7 @@ export const SEAT_INSERT_BATCH_SIZE = 5000;
 type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 /**
- * Insert all sections + their seats in bulk.
+ * Insert all sections + their seats in bulk for a given show.
  *
  * Optimised path:
  * 1. Single INSERT for all sections → 1 round-trip
@@ -32,7 +33,7 @@ type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
  */
 async function insertSectionsWithSeats(
   tx: DbTransaction,
-  eventId: number,
+  showId: number,
   sections: SectionInput[],
 ) {
   // ── 1. Bulk-insert all sections in one statement ──
@@ -40,19 +41,22 @@ async function insertSectionsWithSeats(
     .insert(seatSections)
     .values(
       sections.map((sec) => ({
-        eventId,
+        showId,
         name: sec.name,
         prefix: sec.prefix,
         type: sec.type ?? 'assigned',
         isSeatPickable: sec.is_seat_pickable ?? true,
         rows: sec.rows,
         cols: sec.cols,
+        capacity: sec.capacity ?? 0,
         price: String(sec.price),
         layoutX: sec.layout_x,
         layoutY: sec.layout_y,
         startRowIndex: sec.start_row_index,
         startColIndex: sec.start_col_index,
         sortOrder: sec.sort_order,
+        salesStartAt: sec.sales_start_at ? new Date(sec.sales_start_at) : null,
+        salesEndAt: sec.sales_end_at ? new Date(sec.sales_end_at) : null,
       })),
     )
     .returning();
@@ -75,31 +79,38 @@ async function insertSectionsWithSeats(
     }
 
     const prefix = sec.prefix;
+    const sectionType = sec.type ?? 'assigned';
+
+    // For general admission: use capacity or rows*cols
+    const effectiveRows = sectionType === 'general' ? (sec.capacity ?? sec.rows ?? 0) : sec.rows;
+    const effectiveCols = sectionType === 'general' ? 1 : sec.cols;
+
     const startRow = sec.start_row_index ?? 0;
     const startCol = sec.start_col_index ?? 1;
     const disabledSet = new Set(sec.disabled_seats ?? []);
     let disabled_count = 0;
 
-    for (let r = 0; r < sec.rows; r++) {
-      const rowLabel = getRowLabel(startRow + r);
-      for (let c = 0; c < sec.cols; c++) {
+    for (let r = 0; r < effectiveRows; r++) {
+      const rowLabel = sectionType === 'general' ? '' : getRowLabel(startRow + r);
+      for (let c = 0; c < effectiveCols; c++) {
         const colNumber = startCol + c;
-        const seatKey = `${prefix}-${rowLabel}${colNumber}`;
+        const seatKey =
+          sectionType === 'general' ? `${prefix}-${r + 1}` : `${prefix}-${rowLabel}${colNumber}`;
         const isDisabled = disabledSet.has(seatKey);
         if (isDisabled) disabled_count++;
 
         allSeats.push({
-          eventId,
+          showId,
           sectionId: dbSection.id,
           prefix,
           rowLabel,
-          colNumber,
+          colNumber: sectionType === 'general' ? r + 1 : colNumber,
           status: isDisabled ? 'disabled' : 'available',
         });
       }
     }
 
-    const seat_count = sec.rows * sec.cols;
+    const seat_count = effectiveRows * effectiveCols;
     const available_count = seat_count - disabled_count;
     total_seats += seat_count;
     total_available_seats += available_count;
@@ -109,6 +120,7 @@ async function insertSectionsWithSeats(
       name: dbSection.name,
       rows: dbSection.rows,
       cols: dbSection.cols,
+      capacity: dbSection.capacity,
       seat_count,
       available_count,
       disabled_count,
@@ -121,6 +133,42 @@ async function insertSectionsWithSeats(
   }
 
   return { total_seats, total_available_seats, sectionsInfo };
+}
+
+/**
+ * Insert a show and its sections+seats within a transaction.
+ */
+async function insertShowWithSections(tx: DbTransaction, eventId: number, show: ShowInput) {
+  const [newShow] = await tx
+    .insert(eventShows)
+    .values({
+      eventId,
+      title: show.title || null,
+      showDate: show.show_date,
+      startTime: new Date(show.start_time),
+      endTime: show.end_time ? new Date(show.end_time) : null,
+      itinerary: show.itinerary ?? [],
+      status: 'draft',
+    })
+    .returning();
+
+  const { total_seats, total_available_seats, sectionsInfo } = await insertSectionsWithSeats(
+    tx,
+    newShow.id,
+    show.sections,
+  );
+
+  return {
+    id: newShow.id,
+    title: newShow.title,
+    show_date: newShow.showDate,
+    start_time: newShow.startTime,
+    end_time: newShow.endTime,
+    status: newShow.status,
+    total_seats,
+    total_available_seats,
+    sections: sectionsInfo,
+  };
 }
 
 export const eventService = {
@@ -142,11 +190,8 @@ export const eventService = {
     // Build WHERE conditions
     const conditions = [];
 
-    // Admin sees all events; non-admins see all public statuses (published, sold_out, completed, cancelled)
-    if (role === 'admin') {
-      // No status filter for admins - they see everything
-    } else {
-      // Exclude only draft status - all other statuses are public
+    // Admin sees all events; non-admins see only non-draft
+    if (role !== 'admin') {
       conditions.push(sql`${events.status} != 'draft'`);
     }
 
@@ -158,27 +203,30 @@ export const eventService = {
     // Count total matching events
     const [{ total }] = await db.select({ total: count() }).from(events).where(whereClause);
 
-    // Query events with seat aggregation
+    // Query events with show/seat aggregation
+    // Join events → eventShows → seatSections → seats
     const rows = await db
       .select({
         id: events.id,
         title: events.title,
         venue: events.venue,
-        eventDate: events.eventDate,
         bannerImageUrl: events.bannerImageUrl,
         minAge: events.minAge,
         maxTicketsPerUser: events.maxTicketsPerUser,
         status: events.status,
+        // Earliest show date for display/sorting
+        earliestShowDate: min(eventShows.showDate),
         minPrice: min(seatSections.price),
         totalSeats: count(sql`CASE WHEN ${seats.status} != 'disabled' THEN 1 END`),
         availableSeats: count(sql`CASE WHEN ${seats.status} = 'available' THEN 1 END`),
       })
       .from(events)
-      .leftJoin(seatSections, eq(seatSections.eventId, events.id))
+      .leftJoin(eventShows, eq(eventShows.eventId, events.id))
+      .leftJoin(seatSections, eq(seatSections.showId, eventShows.id))
       .leftJoin(seats, eq(seats.sectionId, seatSections.id))
       .where(whereClause)
       .groupBy(events.id)
-      .orderBy(events.eventDate)
+      .orderBy(min(eventShows.showDate))
       .limit(limit)
       .offset(offset);
 
@@ -187,7 +235,7 @@ export const eventService = {
         id: r.id,
         title: r.title,
         venue: r.venue,
-        event_date: r.eventDate,
+        earliest_show_date: r.earliestShowDate,
         banner_image_url: r.bannerImageUrl,
         min_age: r.minAge,
         max_tickets_per_user: r.maxTicketsPerUser,
@@ -214,33 +262,61 @@ export const eventService = {
     if (!event) throwError(Errors.NOT_FOUND);
 
     // Draft events are only visible to the admin who created them
-    // Other statuses (published, sold_out, completed, cancelled) are public
     if (event.status === 'draft') {
       if (role !== 'admin' || event.createdBy !== userId) {
         throwError(Errors.NOT_FOUND);
       }
     }
 
-    // 2. Get sections ordered by sort_order
-    const sections = await db
+    // 2. Get all shows for this event
+    const shows = await db
       .select()
-      .from(seatSections)
-      .where(eq(seatSections.eventId, eventId))
-      .orderBy(seatSections.sortOrder);
+      .from(eventShows)
+      .where(eq(eventShows.eventId, eventId))
+      .orderBy(eventShows.showDate, eventShows.startTime);
 
-    // 3. Aggregate seat counts per section in a single query (avoid N+1)
-    const seatCounts = await db
-      .select({
-        sectionId: seats.sectionId,
-        seatCount: count(),
-        availableCount: count(sql`CASE WHEN ${seats.status} = 'available' THEN 1 END`),
-        disabledCount: count(sql`CASE WHEN ${seats.status} = 'disabled' THEN 1 END`),
-      })
-      .from(seats)
-      .where(eq(seats.eventId, eventId))
-      .groupBy(seats.sectionId);
+    // 3. Get all sections across all shows
+    const showIds = shows.map((s) => s.id);
+    let allSections: (typeof seatSections.$inferSelect)[] = [];
+    if (showIds.length > 0) {
+      allSections = await db
+        .select()
+        .from(seatSections)
+        .where(
+          sql`${seatSections.showId} IN (${sql.join(
+            showIds.map((id) => sql`${id}`),
+            sql`, `,
+          )})`,
+        )
+        .orderBy(seatSections.sortOrder);
+    }
 
-    // 4. Build a map for O(1) lookup
+    // 4. Aggregate seat counts per section in a single query (avoid N+1)
+    let seatCounts: {
+      sectionId: number;
+      seatCount: number;
+      availableCount: number;
+      disabledCount: number;
+    }[] = [];
+    if (showIds.length > 0) {
+      seatCounts = await db
+        .select({
+          sectionId: seats.sectionId,
+          seatCount: count(),
+          availableCount: count(sql`CASE WHEN ${seats.status} = 'available' THEN 1 END`),
+          disabledCount: count(sql`CASE WHEN ${seats.status} = 'disabled' THEN 1 END`),
+        })
+        .from(seats)
+        .where(
+          sql`${seats.showId} IN (${sql.join(
+            showIds.map((id) => sql`${id}`),
+            sql`, `,
+          )})`,
+        )
+        .groupBy(seats.sectionId);
+    }
+
+    // 5. Build a map for O(1) lookup
     const countsMap = new Map(
       seatCounts.map((sc) => [
         sc.sectionId,
@@ -252,44 +328,78 @@ export const eventService = {
       ]),
     );
 
+    // 6. Group sections by showId
+    const sectionsByShow = new Map<number, typeof allSections>();
+    for (const s of allSections) {
+      const arr = sectionsByShow.get(s.showId) || [];
+      arr.push(s);
+      sectionsByShow.set(s.showId, arr);
+    }
+
     return {
       id: event.id,
       title: event.title,
       description: event.description,
+      terms_and_conditions: event.termsAndConditions,
       venue: event.venue,
-      event_date: event.eventDate,
       banner_image_url: event.bannerImageUrl,
+      static_map_image_url: event.staticMapImageUrl,
+      min_age: event.minAge,
+      max_tickets_per_user: event.maxTicketsPerUser,
+      stage_layout: event.stageLayout,
+      amenities: event.amenities,
+      organizer_info: event.organizerInfo,
       status: event.status,
-      sections: sections.map((s) => {
-        const counts = countsMap.get(s.id) || {
-          seat_count: 0,
-          available_count: 0,
-          disabled_count: 0,
-        };
+      shows: shows.map((show) => {
+        const showSections = sectionsByShow.get(show.id) || [];
         return {
-          id: s.id,
-          name: s.name,
-          type: s.type,
-          prefix: s.prefix,
-          is_seat_pickable: s.isSeatPickable,
-          price: Number(s.price),
-          rows: s.rows,
-          cols: s.cols,
-          layout_x: s.layoutX,
-          layout_y: s.layoutY,
-          start_row_index: s.startRowIndex,
-          start_col_index: s.startColIndex,
-          seat_count: counts.seat_count,
-          available_count: counts.available_count,
-          disabled_count: counts.disabled_count,
+          id: show.id,
+          title: show.title,
+          show_date: show.showDate,
+          start_time: show.startTime,
+          end_time: show.endTime,
+          itinerary: show.itinerary,
+          status: show.status,
+          sections: showSections.map((s) => {
+            const counts = countsMap.get(s.id) || {
+              seat_count: 0,
+              available_count: 0,
+              disabled_count: 0,
+            };
+            return {
+              id: s.id,
+              name: s.name,
+              type: s.type,
+              prefix: s.prefix,
+              is_seat_pickable: s.isSeatPickable,
+              price: Number(s.price),
+              rows: s.rows,
+              cols: s.cols,
+              capacity: s.capacity,
+              layout_x: s.layoutX,
+              layout_y: s.layoutY,
+              start_row_index: s.startRowIndex,
+              start_col_index: s.startColIndex,
+              visual_layout: s.visualLayout,
+              sales_start_at: s.salesStartAt,
+              sales_end_at: s.salesEndAt,
+              seat_count: counts.seat_count,
+              available_count: counts.available_count,
+              disabled_count: counts.disabled_count,
+            };
+          }),
         };
       }),
     };
   },
 
   async createEvent(adminId: number, data: unknown) {
-    const { sections, ...eventData } = validateInput(createEventSchema, data);
-    validateEventRequirements(sections);
+    const { shows, ...eventData } = validateInput(createEventSchema, data);
+
+    // Validate sections for each show
+    for (const show of shows) {
+      validateEventRequirements(show.sections);
+    }
 
     return await db.transaction(async (tx) => {
       const [newEvent] = await tx
@@ -297,63 +407,69 @@ export const eventService = {
         .values({
           title: eventData.title,
           description: eventData.description,
+          termsAndConditions: eventData.terms_and_conditions || null,
           venue: eventData.venue,
-          eventDate: new Date(eventData.event_date),
           bannerImageUrl: eventData.banner_image_url || null,
+          staticMapImageUrl: eventData.static_map_image_url || null,
           minAge: eventData.min_age ?? 0,
           maxTicketsPerUser: eventData.max_tickets_per_user ?? 0,
           stageLayout: eventData.stage_layout ?? [],
+          amenities: eventData.amenities ?? [],
+          organizerInfo: eventData.organizer_info ?? {},
           createdBy: adminId,
           status: 'draft',
         })
         .returning();
 
-      const { total_seats, total_available_seats, sectionsInfo } = await insertSectionsWithSeats(
-        tx,
-        newEvent.id,
-        sections,
-      );
+      const showResults = [];
+      for (const show of shows) {
+        const result = await insertShowWithSections(tx, newEvent.id, show);
+        showResults.push(result);
+      }
 
       return {
         id: newEvent.id,
         title: newEvent.title,
         status: newEvent.status,
-        total_seats,
-        total_available_seats,
-        sections: sectionsInfo,
+        shows: showResults,
       };
     });
   },
 
-  async updateEventSections(adminId: number, eventId: number, data: unknown) {
-    const { sections } = validateInput(updateSectionsSchema, data);
+  async updateShowSections(adminId: number, showId: number, data: unknown) {
+    const { sections } = validateInput(updateShowSectionsSchema, data);
     validateEventRequirements(sections);
 
     return await db.transaction(async (tx) => {
-      const [event] = await tx
+      // Get the show and its parent event
+      const [show] = await tx
         .select()
-        .from(events)
-        .where(eq(events.id, eventId))
+        .from(eventShows)
+        .where(eq(eventShows.id, showId))
         .limit(1)
         .for('update');
+      if (!show) throwError(Errors.NOT_FOUND);
+
+      const [event] = await tx.select().from(events).where(eq(events.id, show.eventId)).limit(1);
       if (!event) throwError(Errors.NOT_FOUND);
       if (event.createdBy !== adminId) throwError(Errors.FORBIDDEN);
-      if (event.status !== 'draft') throwError(Errors.EVENT_NOT_DRAFT);
+      if (show.status !== 'draft') throwError(Errors.EVENT_NOT_DRAFT);
 
-      // Must delete seats first due to FK constraint on seatSections
-      await tx.delete(seats).where(eq(seats.eventId, eventId));
-      await tx.delete(seatSections).where(eq(seatSections.eventId, eventId));
+      // Delete existing seats and sections for this show
+      await tx.delete(seats).where(eq(seats.showId, showId));
+      await tx.delete(seatSections).where(eq(seatSections.showId, showId));
 
       const { total_seats, total_available_seats, sectionsInfo } = await insertSectionsWithSeats(
         tx,
-        event.id,
+        showId,
         sections,
       );
 
       return {
-        id: event.id,
-        title: event.title,
-        status: event.status,
+        show_id: show.id,
+        event_id: event.id,
+        event_title: event.title,
+        show_status: show.status,
         total_seats,
         total_available_seats,
         sections: sectionsInfo,
@@ -372,17 +488,43 @@ export const eventService = {
       if (!event) throwError(Errors.NOT_FOUND);
       if (event.createdBy !== adminId) throwError(Errors.FORBIDDEN);
       if (event.status === 'published') throwError(Errors.ALREADY_PUBLISHED);
+
+      // Check that at least one show has available seats
+      const showList = await tx
+        .select({ id: eventShows.id })
+        .from(eventShows)
+        .where(eq(eventShows.eventId, eventId));
+
+      if (showList.length === 0) throwError(Errors.NO_SEATS);
+
+      const showIds = showList.map((s) => s.id);
       const [hasSeats] = await tx
         .select()
         .from(seats)
-        .where(and(eq(seats.eventId, eventId), eq(seats.status, 'available')))
+        .where(
+          and(
+            sql`${seats.showId} IN (${sql.join(
+              showIds.map((id) => sql`${id}`),
+              sql`, `,
+            )})`,
+            eq(seats.status, 'available'),
+          ),
+        )
         .limit(1);
       if (!hasSeats) throwError(Errors.NO_SEATS);
+
+      // Publish the event and all its draft shows
       const [updated] = await tx
         .update(events)
         .set({ status: 'published' })
         .where(eq(events.id, eventId))
         .returning();
+
+      await tx
+        .update(eventShows)
+        .set({ status: 'published' })
+        .where(and(eq(eventShows.eventId, eventId), eq(eventShows.status, 'draft')));
+
       return { id: updated.id, status: updated.status };
     });
   },

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -32,14 +32,22 @@ const baseSectionSchema = z.object({
   rows: z
     .number(req('Số hàng là bắt buộc'))
     .int('Số hàng phải là số nguyên')
-    .min(1, 'Tối thiểu 1 hàng')
-    .max(50, 'Tối đa 50 hàng'),
+    .min(0, 'Số hàng không được âm')
+    .max(50, 'Tối đa 50 hàng')
+    .default(0),
 
   cols: z
     .number(req('Số cột là bắt buộc'))
     .int('Số cột phải là số nguyên')
-    .min(1, 'Tối thiểu 1 cột')
-    .max(100, 'Tối đa 100 cột'),
+    .min(0, 'Số cột không được âm')
+    .max(100, 'Tối đa 100 cột')
+    .default(0),
+
+  capacity: z
+    .number()
+    .int('Sức chứa phải là số nguyên')
+    .min(0, 'Sức chứa không được âm')
+    .default(0),
 
   price: z.number(req('Giá là bắt buộc')).positive('Giá phải lớn hơn 0'),
 
@@ -59,11 +67,55 @@ const baseSectionSchema = z.object({
     .default([]),
 
   sort_order: z.number().int().min(0).default(0),
+
+  sales_start_at: z
+    .string()
+    .pipe(z.iso.datetime({ offset: true }))
+    .optional()
+    .or(z.literal('')),
+
+  sales_end_at: z
+    .string()
+    .pipe(z.iso.datetime({ offset: true }))
+    .optional()
+    .or(z.literal('')),
 });
 
 // Thêm cross-field validation: disabled_seats phải nằm trong phạm vi section và có đúng prefix
 const sectionSchema = baseSectionSchema.superRefine((section, ctx) => {
+  // For assigned sections, rows and cols must be > 0
+  if (section.type === 'assigned') {
+    if (section.rows < 1) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['rows'],
+        message: 'Khu vực assigned phải có ít nhất 1 hàng',
+      });
+    }
+    if (section.cols < 1) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['cols'],
+        message: 'Khu vực assigned phải có ít nhất 1 cột',
+      });
+    }
+  }
+
+  // For general admission, capacity must be > 0
+  if (section.type === 'general') {
+    if (section.capacity < 1) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['capacity'],
+        message: 'Khu vực general admission phải có sức chứa > 0',
+      });
+    }
+  }
+
   if (!section.disabled_seats || section.disabled_seats.length === 0) return;
+
+  // Disabled seats validation only applies to assigned sections
+  if (section.type === 'general') return;
 
   const startRow = section.start_row_index;
   const endRow = startRow + section.rows - 1;
@@ -126,8 +178,32 @@ const sectionSchema = baseSectionSchema.superRefine((section, ctx) => {
   }
 });
 
-// ── Event Schema ───────────────────────────────
-// ── Stage layout item schema ───────────────────
+// ── Itinerary Item Schema ──────────────────────
+const itineraryItemSchema = z.object({
+  time: z.string().min(1, 'Thời gian không được trống'),
+  activity: z.string().min(1, 'Hoạt động không được trống'),
+  description: z.string().default(''),
+});
+
+// ── Show Schema ────────────────────────────────
+const showSchema = z.object({
+  title: z.string().max(200, 'Tên suất diễn tối đa 200 ký tự').optional().or(z.literal('')),
+
+  show_date: z.iso.date('Ngày diễn không hợp lệ'),
+
+  start_time: z.string(req('Giờ bắt đầu là bắt buộc')).pipe(z.iso.datetime({ offset: true })),
+
+  end_time: z
+    .string()
+    .pipe(z.iso.datetime({ offset: true }))
+    .optional()
+    .or(z.literal('')),
+
+  itinerary: z.array(itineraryItemSchema).default([]),
+
+  sections: z.array(sectionSchema).min(1, 'Mỗi suất diễn phải có ít nhất 1 khu vực ghế'),
+});
+
 // ── Stage layout item schema (discriminated union) ──
 const baseStageItem = { id: z.string(), label: z.string(), x: z.number(), y: z.number() };
 
@@ -141,56 +217,69 @@ const stageLayoutItemSchema = z.discriminatedUnion('type', [
   }),
 ]);
 
-export const createEventSchema = z
+// ── Organizer Info Schema ──────────────────────
+const organizerInfoSchema = z
   .object({
-    title: z
-      .string(req('Tên sự kiện là bắt buộc'))
-      .min(5, 'Tên sự kiện tối thiểu 5 ký tự')
-      .max(200, 'Tên sự kiện tối đa 200 ký tự'),
-
-    description: z.string(req('Mô tả là bắt buộc')).min(1, 'Mô tả không được trống'),
-
-    venue: z.string(req('Địa điểm là bắt buộc')).min(1, 'Địa điểm không được trống'),
-
-    event_date: z
-      .string(req('Ngày sự kiện là bắt buộc'))
-      .pipe(z.iso.datetime({ offset: true }))
-      .check(z.refine((val) => new Date(val) > new Date(), 'Ngày sự kiện phải trong tương lai')),
-
-    banner_image_url: z
-      .url('URL ảnh không hợp lệ')
-      .refine((url) => /^https?:\/\//i.test(url), 'URL ảnh phải bắt đầu bằng http:// hoặc https://')
-      .optional()
-      .or(z.literal('')),
-
-    min_age: z.number().int().min(0, 'Tuổi tối thiểu không được âm').default(0),
-
-    max_tickets_per_user: z
-      .number()
-      .int()
-      .min(0, 'Giới hạn vé không được âm (0 = không giới hạn)')
-      .default(0),
-
-    stage_layout: z.array(stageLayoutItemSchema).default([]),
-
-    sections: z.array(sectionSchema).min(1, 'Phải có ít nhất 1 khu vực ghế'),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    phone: z.string().optional(),
+    website: z.string().optional(),
   })
-  .check(
-    z.refine((data) => {
-      const totalSeats = data.sections.reduce((sum, s) => sum + s.rows * s.cols, 0);
-      return totalSeats <= 50_000;
-    }, 'Tổng số ghế không được vượt quá 50,000'),
-  );
+  .optional();
 
-// ── Update Sections Schema ─────────────────────
-export const updateSectionsSchema = z.object({
+// ── Event Schema (Create) ──────────────────────
+export const createEventSchema = z.object({
+  title: z
+    .string(req('Tên sự kiện là bắt buộc'))
+    .min(5, 'Tên sự kiện tối thiểu 5 ký tự')
+    .max(200, 'Tên sự kiện tối đa 200 ký tự'),
+
+  description: z.string(req('Mô tả là bắt buộc')).min(1, 'Mô tả không được trống'), // Markdown
+
+  terms_and_conditions: z.string().optional().or(z.literal('')), // Markdown
+
+  venue: z.string(req('Địa điểm là bắt buộc')).min(1, 'Địa điểm không được trống'),
+
+  banner_image_url: z
+    .url('URL ảnh không hợp lệ')
+    .refine((url) => /^https?:\/\//i.test(url), 'URL ảnh phải bắt đầu bằng http:// hoặc https://')
+    .optional()
+    .or(z.literal('')),
+
+  static_map_image_url: z
+    .url('URL ảnh sơ đồ không hợp lệ')
+    .refine((url) => /^https?:\/\//i.test(url), 'URL ảnh phải bắt đầu bằng http:// hoặc https://')
+    .optional()
+    .or(z.literal('')),
+
+  min_age: z.number().int().min(0, 'Tuổi tối thiểu không được âm').default(0),
+
+  max_tickets_per_user: z
+    .number()
+    .int()
+    .min(0, 'Giới hạn vé không được âm (0 = không giới hạn)')
+    .default(0),
+
+  stage_layout: z.array(stageLayoutItemSchema).default([]),
+
+  amenities: z.array(z.string()).default([]),
+
+  organizer_info: organizerInfoSchema,
+
+  shows: z.array(showSchema).min(1, 'Phải có ít nhất 1 suất diễn'),
+});
+
+// ── Update Show Sections Schema ────────────────
+export const updateShowSectionsSchema = z.object({
   sections: z.array(sectionSchema).min(1, 'Phải có ít nhất 1 khu vực ghế'),
 });
 
 // ── Types ──────────────────────────────────────
 export type CreateEventInput = z.infer<typeof createEventSchema>;
-export type UpdateSectionsInput = z.infer<typeof updateSectionsSchema>;
+export type UpdateShowSectionsInput = z.infer<typeof updateShowSectionsSchema>;
 export type SectionInput = z.infer<typeof sectionSchema>;
+export type ShowInput = z.infer<typeof showSchema>;
+export type ItineraryItem = z.infer<typeof itineraryItemSchema>;
 
 /** Form-side section type: disabled_seats is a comma-separated string instead of string[] */
 export type SectionFormData = Omit<SectionInput, 'disabled_seats'> & { disabled_seats: string };
@@ -204,6 +293,7 @@ const sectionFormDraftSchema = z.object({
   price: z.number(),
   rows: z.number().int(),
   cols: z.number().int(),
+  capacity: z.number().int().default(0),
   layout_x: z.number(),
   layout_y: z.number(),
   start_row_index: z.number(),
@@ -212,22 +302,27 @@ const sectionFormDraftSchema = z.object({
   sort_order: z.number(),
 });
 
+const showFormDraftSchema = z.object({
+  title: z.string().default(''),
+  show_date: z.string().default(''),
+  start_time: z.string().default(''),
+  end_time: z.string().default(''),
+  itinerary: z.array(itineraryItemSchema).default([]),
+  sections: z.array(sectionFormDraftSchema).min(1),
+});
+
 export const formDraftSchema = z.object({
   title: z.string(),
   description: z.string(),
+  terms_and_conditions: z.string().default(''),
   venue: z.string(),
-  date: z
-    .object({
-      year: z.number().int(),
-      month: z.number().int().min(1).max(12),
-      day: z.number().int().min(1).max(31),
-    })
-    .optional(),
-  selectedHour: z.string(),
-  selectedMinute: z.string(),
-  selectedPeriod: z.enum(['AM', 'PM']),
   bannerImageUrl: z.string(),
-  sections: z.array(sectionFormDraftSchema).min(1),
+  staticMapImageUrl: z.string().default(''),
+  min_age: z.number().int().default(0),
+  max_tickets_per_user: z.number().int().default(0),
+  amenities: z.array(z.string()).default([]),
+  organizer_info: organizerInfoSchema,
+  shows: z.array(showFormDraftSchema).min(1),
 });
 
 export type FormDraft = z.infer<typeof formDraftSchema>;
@@ -243,3 +338,6 @@ export type EventQueryInput = z.infer<typeof eventQuerySchema>;
 
 // ── Event ID Schema (path param validation) ────
 export const eventIdSchema = z.coerce.number().int().positive('ID sự kiện không hợp lệ');
+
+// ── Show ID Schema (path param validation) ─────
+export const showIdSchema = z.coerce.number().int().positive('ID suất diễn không hợp lệ');

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -186,23 +186,41 @@ const itineraryItemSchema = z.object({
 });
 
 // ── Show Schema ────────────────────────────────
-const showSchema = z.object({
-  title: z.string().max(200, 'Tên suất diễn tối đa 200 ký tự').optional().or(z.literal('')),
+const showSchema = z
+  .object({
+    title: z.string().max(200, 'Tên suất diễn tối đa 200 ký tự').optional().or(z.literal('')),
 
-  show_date: z.iso.date('Ngày diễn không hợp lệ'),
+    show_date: z.iso.date('Ngày diễn không hợp lệ'),
 
-  start_time: z.string(req('Giờ bắt đầu là bắt buộc')).pipe(z.iso.datetime({ offset: true })),
+    start_time: z.string(req('Giờ bắt đầu là bắt buộc')).pipe(z.iso.datetime({ offset: true })),
 
-  end_time: z
-    .string()
-    .pipe(z.iso.datetime({ offset: true }))
-    .optional()
-    .or(z.literal('')),
+    end_time: z
+      .string()
+      .pipe(z.iso.datetime({ offset: true }))
+      .optional()
+      .or(z.literal('')),
 
-  itinerary: z.array(itineraryItemSchema).default([]),
+    itinerary: z.array(itineraryItemSchema).default([]),
 
-  sections: z.array(sectionSchema).min(1, 'Mỗi suất diễn phải có ít nhất 1 khu vực ghế'),
-});
+    sections: z.array(sectionSchema).min(1, 'Mỗi suất diễn phải có ít nhất 1 khu vực ghế'),
+  })
+  .superRefine((show, ctx) => {
+    if (show.show_date !== show.start_time.slice(0, 10)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['show_date'],
+        message: 'Ngày diễn phải khớp với ngày bắt đầu của suất diễn',
+      });
+    }
+
+    if (show.end_time && show.end_time !== '' && new Date(show.end_time) <= new Date(show.start_time)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['end_time'],
+        message: 'Giờ kết thúc phải sau giờ bắt đầu',
+      });
+    }
+  });
 
 // ── Stage layout item schema (discriminated union) ──
 const baseStageItem = { id: z.string(), label: z.string(), x: z.number(), y: z.number() };


### PR DESCRIPTION
Closes #58 

## Loại thay đổi

- [x] ✨ Feature mới
- [x] ♻️ Refactor

## Screenshots / Demo

<!-- Paste ảnh hoặc video nếu có thay đổi UI. Xóa mục này nếu không cần. -->

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events can have multiple shows (dates/times) with per-show itineraries.
  * Per-show seating sections with capacities and configurable sales windows.
  * Added organizer info, terms & conditions, static map images, and amenities.
  * Order items include unique ticket codes.

* **Refactor**
  * Event model and UI now present shows under events (earliest show date shown in listings).
  * Simplified order model by removing event-level association.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->