### PR TITLE
feat: implement API customer get tickets

### DIFF
--- a/src/lib/server/services/order.service.ts
+++ b/src/lib/server/services/order.service.ts
@@ -1,12 +1,78 @@
 import { db } from '$lib/server/db';
 import { orderItems, orders, seats, seatSections } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, gte, eq, inArray, or, desc } from 'drizzle-orm';
 
 /* ================= TYPE ================= */
 
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type Order = typeof orders.$inferSelect;
+
+type OrderItemWithRelations = typeof orderItems.$inferSelect & {
+  seat: typeof seats.$inferSelect & {
+    section: typeof seatSections.$inferSelect;
+    show: {
+      title: string | null;
+      startTime: Date;
+      event: {
+        id: number;
+        title: string;
+        venue: string;
+        bannerImageUrl: string | null;
+      };
+    };
+  };
+};
+
+type FormattedItem = {
+  event: { id: number; title: string; venue: string; bannerImageUrl: string | null };
+  show: { title: string | null; startTime: Date };
+  item_id: number;
+  price: string;
+  ticket_code: string;
+  section_name: string;
+  seat_type: 'assigned' | 'general';
+  seat_label: string | null;
+};
+
+type PendingOrderEntry = {
+  order_id: number;
+  total_amount: string;
+  status: 'pending';
+  expires_at: string;
+  created_at: string;
+  items: {
+    event_title: string;
+    show_title: string | null;
+    section_name: string;
+    seat_type: 'assigned' | 'general';
+    seat_label: string | null;
+    price: string;
+  }[];
+};
+
+type PaidTicketEntry = {
+  event: { id: number; title: string; venue: string; bannerImageUrl: string | null };
+  ticket: {
+    order_item_id: number;
+    show_title: string | null;
+    start_time: string;
+    section_name: string;
+    seat_type: 'assigned' | 'general';
+    seat_label: string | null;
+    ticket_code: string;
+    qr_code: null;
+    paid_at: string | null;
+  };
+};
+
+type PaidEventEntry = {
+  event_id: number;
+  title: string;
+  venue: string;
+  banner_image_url: string | null;
+  tickets: PaidTicketEntry['ticket'][];
+};
 
 /* ================= HELPER ================= */
 
@@ -126,16 +192,25 @@ export const orderService = {
   },
 
   /**
-   * Lấy danh sách toàn bộ vé (orders đã thanh toán) của một User.
+   * Lấy lịch sử mua vé của User (Pending Orders & Paid Events).
+   * Tự động ẩn số ghế đối với khu vực vé đứng (General Admission).
    */
-  async getMyTickets(userId: number) {
+  async getMyOrdersAndTickets(userId: number) {
     /**
-     * Query database bằng drizzle relational API.
-     * Tự động JOIN 6 bảng lại với nhau.
+     * 1. Query: Lấy tất cả đơn hàng (đã thanh toán hoặc đang chờ thanh toán mà chưa hết hạn).
+     * Query trực tiếp điều kiện thời gian, thay vì lấy hết rồi mới lọc.
      */
-    const rawOrders = await db.query.orders.findMany({
-      where: and(eq(orders.userId, userId), eq(orders.status, 'paid')),
-      orderBy: [desc(orders.paidAt)],
+    const now = new Date();
+
+    const userOrders = await db.query.orders.findMany({
+      where: and(
+        eq(orders.userId, userId),
+        or(
+          eq(orders.status, 'paid'),
+          and(eq(orders.status, 'pending'), gte(orders.expiresAt, now)),
+        ),
+      ),
+      orderBy: [desc(orders.createdAt)],
       with: {
         items: {
           with: {
@@ -154,51 +229,98 @@ export const orderService = {
       },
     });
 
-    if (rawOrders.length === 0) {
-      return [];
-    }
+    const pendingOrders: PendingOrderEntry[] = [];
+    const paidTicketsFlatList: PaidTicketEntry[] = [];
 
-    return rawOrders.map((order) => {
-      const firstItemSeat = order.items[0]?.seat;
-      const showInfo = firstItemSeat?.show;
-      const eventInfo = showInfo?.event;
+    for (const order of userOrders) {
+      const formatItem = (item: OrderItemWithRelations): FormattedItem => {
+        const seat = item.seat;
+        const section = seat.section;
+        const isGeneral = section.type === 'general';
 
-      return {
-        order_id: order.id,
-        total_amount: Number(order.totalAmount).toFixed(2),
-        paid_at: order.paidAt ? order.paidAt.toISOString() : null,
+        let seatLabel: string | null = null;
 
-        event: eventInfo
-          ? {
-              id: eventInfo.id,
-              title: eventInfo.title,
-              venue: eventInfo.venue,
-              banner_image_url: eventInfo.bannerImageUrl,
-            }
-          : null,
+        if (!isGeneral) {
+          const rowCol = `${seat.rowLabel}${seat.colNumber}`;
+          seatLabel = seat.prefix ? `${seat.prefix}-${rowCol}` : rowCol;
+        }
 
-        show: showInfo
-          ? {
-              id: showInfo.id,
-              title: showInfo.title,
-              show_date: showInfo.showDate,
-              start_time: showInfo.startTime,
-            }
-          : null,
-
-        items: order.items.map((item) => ({
-          id: item.id,
+        return {
+          event: seat.show.event,
+          show: seat.show,
+          item_id: item.id,
+          price: Number(item.priceSnapshot).toFixed(2),
           ticket_code: item.ticketCode,
-          seat_id: item.seatId,
-          section_name: item.seat.section.name,
-          prefix: item.seat.prefix,
-          row_label: item.seat.rowLabel,
-          col_number: item.seat.colNumber,
-          price_snapshot: Number(item.priceSnapshot).toFixed(2),
-          is_checked_in: item.isCheckedIn,
-          qr_code: null,
-        })),
+
+          section_name: section.name,
+          seat_type: section.type,
+          seat_label: seatLabel,
+        };
       };
-    });
+
+      if (order.status === 'pending') {
+        pendingOrders.push({
+          order_id: order.id,
+          total_amount: Number(order.totalAmount).toFixed(2),
+          status: 'pending',
+          expires_at: order.expiresAt.toISOString(),
+          created_at: order.createdAt.toISOString(),
+
+          items: order.items.map((item) => {
+            const formatted = formatItem(item);
+            return {
+              event_title: formatted.event.title,
+              show_title: formatted.show.title,
+              section_name: formatted.section_name,
+              seat_type: formatted.seat_type,
+              seat_label: formatted.seat_label,
+              price: formatted.price,
+            };
+          }),
+        });
+      } else if (order.status === 'paid') {
+        order.items.forEach((item) => {
+          const formatted = formatItem(item);
+          paidTicketsFlatList.push({
+            event: formatted.event,
+            ticket: {
+              order_item_id: formatted.item_id,
+              show_title: formatted.show.title,
+              start_time: formatted.show.startTime.toISOString(),
+              section_name: formatted.section_name,
+              seat_type: formatted.seat_type,
+              seat_label: formatted.seat_label,
+              ticket_code: formatted.ticket_code,
+              qr_code: null, // Dành cho Sprint 5
+              paid_at: order.paidAt ? order.paidAt.toISOString() : null,
+            },
+          });
+        });
+      }
+    }
+    const paidEventsMap = paidTicketsFlatList.reduce(
+      (acc, curr) => {
+        const eventId = curr.event.id;
+
+        if (!acc[eventId]) {
+          acc[eventId] = {
+            event_id: eventId,
+            title: curr.event.title,
+            venue: curr.event.venue,
+            banner_image_url: curr.event.bannerImageUrl,
+            tickets: [],
+          };
+        }
+
+        acc[eventId].tickets.push(curr.ticket);
+        return acc;
+      },
+      {} as Record<number, PaidEventEntry>,
+    );
+
+    return {
+      pending_orders: pendingOrders,
+      paid_events: Object.values(paidEventsMap),
+    };
   },
 };

--- a/src/lib/server/services/order.service.ts
+++ b/src/lib/server/services/order.service.ts
@@ -1,7 +1,7 @@
 import { db } from '$lib/server/db';
 import { orderItems, orders, seats, seatSections } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 
 /* ================= TYPE ================= */
 
@@ -122,6 +122,83 @@ export const orderService = {
 
       // 8. Xây dựng response
       return await buildOrderResponse(tx, orderId, now, order);
+    });
+  },
+
+  /**
+   * Lấy danh sách toàn bộ vé (orders đã thanh toán) của một User.
+   */
+  async getMyTickets(userId: number) {
+    /**
+     * Query database bằng drizzle relational API.
+     * Tự động JOIN 6 bảng lại với nhau.
+     */
+    const rawOrders = await db.query.orders.findMany({
+      where: and(eq(orders.userId, userId), eq(orders.status, 'paid')),
+      orderBy: [desc(orders.paidAt)],
+      with: {
+        items: {
+          with: {
+            seat: {
+              with: {
+                section: true,
+                show: {
+                  with: {
+                    event: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (rawOrders.length === 0) {
+      return [];
+    }
+
+    return rawOrders.map((order) => {
+      const firstItemSeat = order.items[0]?.seat;
+      const showInfo = firstItemSeat?.show;
+      const eventInfo = showInfo?.event;
+
+      return {
+        order_id: order.id,
+        total_amount: Number(order.totalAmount).toFixed(2),
+        paid_at: order.paidAt ? order.paidAt.toISOString() : null,
+
+        event: eventInfo
+          ? {
+              id: eventInfo.id,
+              title: eventInfo.title,
+              venue: eventInfo.venue,
+              banner_image_url: eventInfo.bannerImageUrl,
+            }
+          : null,
+
+        show: showInfo
+          ? {
+              id: showInfo.id,
+              title: showInfo.title,
+              show_date: showInfo.showDate,
+              start_time: showInfo.startTime,
+            }
+          : null,
+
+        items: order.items.map((item) => ({
+          id: item.id,
+          ticket_code: item.ticketCode,
+          seat_id: item.seatId,
+          section_name: item.seat.section.name,
+          prefix: item.seat.prefix,
+          row_label: item.seat.rowLabel,
+          col_number: item.seat.colNumber,
+          price_snapshot: Number(item.priceSnapshot).toFixed(2),
+          is_checked_in: item.isCheckedIn,
+          qr_code: null,
+        })),
+      };
     });
   },
 };

--- a/src/lib/server/services/order.service.ts
+++ b/src/lib/server/services/order.service.ts
@@ -1,7 +1,7 @@
 import { db } from '$lib/server/db';
 import { orderItems, orders, seats, seatSections } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
-import { and, gte, eq, inArray, or, desc } from 'drizzle-orm';
+import { and, gt, eq, inArray, or, desc } from 'drizzle-orm';
 
 /* ================= TYPE ================= */
 
@@ -207,7 +207,7 @@ export const orderService = {
         eq(orders.userId, userId),
         or(
           eq(orders.status, 'paid'),
-          and(eq(orders.status, 'pending'), gte(orders.expiresAt, now)),
+          and(eq(orders.status, 'pending'), gt(orders.expiresAt, now)),
         ),
       ),
       orderBy: [desc(orders.createdAt)],

--- a/src/lib/server/services/order.service.ts
+++ b/src/lib/server/services/order.service.ts
@@ -298,25 +298,29 @@ export const orderService = {
         });
       }
     }
-    const paidEventsMap = paidTicketsFlatList.reduce(
-      (acc, curr) => {
-        const eventId = curr.event.id;
 
-        if (!acc[eventId]) {
-          acc[eventId] = {
-            event_id: eventId,
-            title: curr.event.title,
-            venue: curr.event.venue,
-            banner_image_url: curr.event.bannerImageUrl,
-            tickets: [],
-          };
-        }
+    const paidEventsMap = new Map<number, PaidEventEntry>();
 
-        acc[eventId].tickets.push(curr.ticket);
-        return acc;
-      },
-      {} as Record<number, PaidEventEntry>,
-    );
+    for (const { event, ticket } of paidTicketsFlatList) {
+      const eventId = event.id;
+
+      if (!paidEventsMap.has(eventId)) {
+        paidEventsMap.set(eventId, {
+          event_id: eventId,
+          title: event.title,
+          venue: event.venue,
+          banner_image_url: event.bannerImageUrl,
+          tickets: [],
+        });
+      }
+
+      paidEventsMap.get(eventId)!.tickets.push(ticket);
+    }
+
+    return {
+      pending_orders: pendingOrders,
+      paid_events: Array.from(paidEventsMap.values()), 
+    };
 
     return {
       pending_orders: pendingOrders,

--- a/src/lib/server/services/order.service.ts
+++ b/src/lib/server/services/order.service.ts
@@ -319,12 +319,7 @@ export const orderService = {
 
     return {
       pending_orders: pendingOrders,
-      paid_events: Array.from(paidEventsMap.values()), 
-    };
-
-    return {
-      pending_orders: pendingOrders,
-      paid_events: Object.values(paidEventsMap),
+      paid_events: Array.from(paidEventsMap.values()),
     };
   },
 };

--- a/src/routes/api/me/tickets/+server.ts
+++ b/src/routes/api/me/tickets/+server.ts
@@ -8,10 +8,10 @@ export const GET = apiHandler(async ({ locals }) => {
   const user = requireAuth(locals);
 
   if (user.role !== 'customer') {
-    throwError(Errors.FORBIDDEN, 'Chỉ khách hàng mới có quyền xem vé của mình.');
+    throwError(Errors.FORBIDDEN, 'Chỉ khách hàng mới có quyền xem vé của mình');
   }
 
-  const tickets = await orderService.getMyTickets(user.id);
+  const dashboardData = await orderService.getMyOrdersAndTickets(user.id);
 
-  return json({ data: tickets }, { status: 200 });
+  return json({ data: dashboardData }, { status: 200 });
 });

--- a/src/routes/api/me/tickets/+server.ts
+++ b/src/routes/api/me/tickets/+server.ts
@@ -1,0 +1,17 @@
+import { json } from '@sveltejs/kit';
+import { apiHandler } from '$lib/server/handler';
+import { requireAuth } from '$lib/server/auth/guards';
+import { orderService } from '$lib/server/services/order.service';
+import { Errors, throwError } from '$lib/server/errors';
+
+export const GET = apiHandler(async ({ locals }) => {
+  const user = requireAuth(locals);
+
+  if (user.role !== 'customer') {
+    throwError(Errors.FORBIDDEN, 'Chỉ khách hàng mới có quyền xem vé của mình.');
+  }
+
+  const tickets = await orderService.getMyTickets(user.id);
+
+  return json({ data: tickets }, { status: 200 });
+});


### PR DESCRIPTION
## Mô tả
Chức năng Customer có thể xem được vé đã mua với `GET /api/me/tickets`

Closes #24 

## Loại thay đổi

- [x] ✨ Feature mới

## Screenshots / Demo

### Người dùng chưa mua vé
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/db478fca-49fb-4876-820e-e18ec45e22b6" />

### Chưa đăng nhập nhưng vào xem vé
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0ceb2272-c226-4d4d-a378-d03b731baaa4" />

### Người dùng đã mua vé
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7918aeb4-f142-4efc-8747-b7d7f74d4f43" />


## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can retrieve a combined view of their tickets: paid tickets grouped by event with ticket details (seat type/label, show title, start time, payment timestamp) and pending orders listed with expiry and formatted price.
  * General Admission seats hide specific seat labels where applicable.

* **Access**
  * Only authenticated customers can view their own ticket data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->