### PR TITLE
feat(cart): implement multi-show cart functionality with dynamic seat management

### DIFF
--- a/src/lib/components/customer/layout/CustomerNavbar.svelte
+++ b/src/lib/components/customer/layout/CustomerNavbar.svelte
@@ -203,14 +203,10 @@
         <!-- Profile / Auth -->
         {#if user}
           <DropdownMenu bind:open={isUserMenuOpen}>
-            <DropdownMenuTrigger>
-              <Button
-                variant="ghost"
-                size="icon"
-                class="h-9 w-9 cursor-pointer text-muted-foreground hover:text-foreground"
-              >
-                <CircleUserRound class="size-6" />
-              </Button>
+            <DropdownMenuTrigger
+              class="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <CircleUserRound class="size-6" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" class="w-48">
               <DropdownMenuItem

--- a/src/lib/components/seat-map/SeatMap.svelte
+++ b/src/lib/components/seat-map/SeatMap.svelte
@@ -6,6 +6,7 @@
 -->
 <script lang="ts">
   import type { SeatSelectionStore } from '$lib/stores/seat-selection-store.svelte';
+  import { toast } from '$lib/stores/toast';
   import type { MapConfig, SeatMapSeat, SeatMapSection, StageElement } from '$lib/types/seat-map';
   import { formatPrice } from '$lib/utils/price';
   import { getRowLabel } from '$lib/utils/seat-label';
@@ -264,12 +265,33 @@
   );
 
   // ── Seat click ──
+  let lastLimitToastTime = 0;
+  const LIMIT_TOAST_COOLDOWN = 2000; // ms — suppress duplicate toasts within this window
+
+  function showLimitToast() {
+    const now = Date.now();
+    if (now - lastLimitToastTime < LIMIT_TOAST_COOLDOWN) return;
+    lastLimitToastTime = now;
+    toast.warning(`Bạn chỉ được chọn tối đa ${store!.maxTickets} vé.`);
+  }
+
   function handleSeatClick(e: Event, sec: SeatMapSection, seatId: number, status: string) {
     if (readonly || !store) return;
     e.stopPropagation();
     if (didDrag) return;
     if (sec.type !== 'assigned') return;
-    if (status !== 'available' && !store.isSeatSelected(seatId)) return;
+
+    const isCurrentlySelected = store.isSeatSelected(seatId);
+
+    // Only allow clicking available seats (to select) or already-selected seats (to deselect)
+    if (status !== 'available' && !isCurrentlySelected) return;
+
+    // If user is trying to ADD a new seat while at the limit, show warning instead
+    if (!isCurrentlySelected && store.isAtLimit) {
+      showLimitToast();
+      return;
+    }
+
     const seat = sec.seats.find((s) => s.id === seatId);
     if (!seat) return;
     const prefix = seat.prefix ? `${seat.prefix}-` : '';

--- a/src/lib/components/seat-map/SectionLegend.svelte
+++ b/src/lib/components/seat-map/SectionLegend.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SeatSelectionStore } from '$lib/stores/seat-selection-store.svelte';
+  import { toast } from '$lib/stores/toast';
   import type { SeatMapSection } from '$lib/types/seat-map';
   import { formatPrice } from '$lib/utils/price';
   import { Minus, Plus } from 'lucide-svelte';
@@ -27,9 +28,23 @@
     return store.getGeneralQuantity(sectionId);
   }
 
+  let lastLimitToastTime = 0;
+  const LIMIT_TOAST_COOLDOWN = 2000;
+
+  function showLimitToast() {
+    const now = Date.now();
+    if (now - lastLimitToastTime < LIMIT_TOAST_COOLDOWN) return;
+    lastLimitToastTime = now;
+    toast.warning(`Bạn chỉ được chọn tối đa ${store.maxTickets} vé.`);
+  }
+
   function increment(section: SeatMapSection) {
     const qty = getQuantity(section.id);
     const avail = availableCount(section);
+    if (store.isAtLimit) {
+      showLimitToast();
+      return;
+    }
     if (qty < avail) {
       store.setGeneralQuantity(section.id, qty + 1);
     }

--- a/src/lib/components/seat-map/SummaryBar.svelte
+++ b/src/lib/components/seat-map/SummaryBar.svelte
@@ -224,12 +224,12 @@
 
                 <!-- General admission -->
                 {#each generalEntries as entry (entry.sectionId)}
-                  <div class="flex items-center justify-between px-3 py-2.5">
+                  <div class="flex items-center justify-between px-3 py-2.5 text-[12px]">
                     <div>
-                      <p class="text-[10px] font-semibold tracking-wide text-primary uppercase">
+                      <p class=" font-semibold tracking-wide text-primary uppercase">
                         {entry.sectionName}
                       </p>
-                      <p class="mt-0.5 text-[11px] text-muted-foreground">
+                      <p class="mx-2 mt-0.5 font-semibold">
                         Vé đứng × {entry.qty}
                       </p>
                     </div>

--- a/src/lib/components/seat-map/SummaryBar.svelte
+++ b/src/lib/components/seat-map/SummaryBar.svelte
@@ -7,6 +7,7 @@
     ChevronDown,
     ChevronsUp,
     ChevronUp,
+    ShieldAlert,
     ShoppingCart,
     Trash2,
     X,
@@ -137,6 +138,19 @@
           </div>
         </div>
 
+        <!-- Warning banner -->
+        <div
+          class="mx-4 mb-2 flex items-start gap-2 rounded-lg border border-warning-border bg-warning-muted px-3 py-2 sm:mx-6 lg:mx-8"
+        >
+          <ShieldAlert class="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
+          <p class="text-[12px] leading-snug text-warning-muted-foreground md:text-sm">
+            Vé trong giỏ <span class="font-bold">chưa được giữ chỗ</span>
+            và có thể bị người khác đặt trước. Hãy nhấn
+            <span class="font-bold">Tiếp tục</span>
+            để tiến hành thanh toán sớm nhất có thể.
+          </p>
+        </div>
+
         <!-- Cart items (scrollable) -->
         <div class="flex-1 space-y-3 overflow-y-auto px-4 pb-20 sm:px-6 lg:px-8">
           {#each activeCarts as cart (cart.showId)}
@@ -156,7 +170,7 @@
                 >
                   <div class="flex items-center gap-2">
                     <Calendar class="h-3.5 w-3.5 text-primary" />
-                    <span class="text-[11px] font-bold text-primary">
+                    <span class="text-sm font-bold text-primary">
                       {cart.showLabel}
                     </span>
                   </div>
@@ -177,20 +191,20 @@
                 {#each Object.entries(groupedSeats) as [_sectionId, group] (_sectionId)}
                   <div class="px-3 py-2.5">
                     <p
-                      class="mb-1.5 text-[10px] font-semibold tracking-wide text-primary uppercase"
+                      class="mb-1.5 text-[12px] font-semibold tracking-wide text-primary uppercase"
                     >
                       {group.sectionName}
                     </p>
-                    <div class="space-y-1">
+                    <div class="mx-2 space-y-2">
                       {#each group.seats as seat (seat.id)}
-                        <div class="flex items-center justify-between gap-2">
+                        <div class="flex items-center justify-between gap-2 text-[12px]">
                           <span
-                            class="inline-flex h-5 items-center rounded bg-surface-container-highest px-1.5 text-[10px] font-semibold text-foreground"
+                            class="inline-flex h-5 items-center rounded bg-surface-container-highest px-1.5 font-semibold text-foreground"
                           >
                             {seat.label}
                           </span>
                           <div class="flex shrink-0 items-center gap-1.5">
-                            <span class="text-[11px] font-semibold text-foreground">
+                            <span class="font-semibold text-foreground">
                               {formatPrice(seat.price)}
                             </span>
                             <button

--- a/src/lib/components/seat-map/SummaryBar.svelte
+++ b/src/lib/components/seat-map/SummaryBar.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import type { SeatSelectionStore } from '$lib/stores/seat-selection-store.svelte';
+  import type { SeatSelectionStore, ShowCart } from '$lib/stores/seat-selection-store.svelte';
   import { formatPrice } from '$lib/utils/price';
   import {
     ArrowRight,
+    Calendar,
     ChevronDown,
     ChevronsUp,
     ChevronUp,
@@ -23,44 +24,44 @@
   let expanded = $state(false);
   let hasSelection = $derived(store.totalCount > 0);
 
-  /** Group selected assigned seats by section */
-  let groupedSeats = $derived.by(() => {
+  /** Get all active carts (carts with selections) */
+  let activeCarts = $derived(store.getActiveCarts());
+  let isMultiShow = $derived(activeCarts.length > 1);
+
+  /** Group selected assigned seats by section for a given cart */
+  function groupSeatsBySection(cart: ShowCart) {
     const groups: Record<
       number,
       { sectionName: string; seats: { id: number; label: string; price: number }[] }
     > = {};
-    for (const seat of store.selectedSeats) {
+    for (const seat of cart.selectedSeats) {
       if (!groups[seat.sectionId]) {
         groups[seat.sectionId] = { sectionName: seat.sectionName, seats: [] };
       }
       groups[seat.sectionId].seats.push({ id: seat.id, label: seat.label, price: seat.price });
     }
     return groups;
-  });
+  }
 
-  /** General admission entries */
-  let generalEntries = $derived.by(() => {
+  /** General admission entries for a given cart */
+  function getGeneralEntries(cart: ShowCart) {
     const entries: {
       sectionId: number;
       sectionName: string;
       qty: number;
-      unitPrice: number;
-      total: number;
     }[] = [];
-    for (const [sectionId, qty] of Object.entries(store.generalQuantities)) {
+    for (const [sectionId, qty] of Object.entries(cart.generalQuantities)) {
       if (qty > 0) {
         const sid = Number(sectionId);
         entries.push({
           sectionId: sid,
           sectionName: `Khu vực #${sid}`,
           qty,
-          unitPrice: 0,
-          total: 0,
         });
       }
     }
     return entries;
-  });
+  }
 
   function toggleExpand() {
     expanded = !expanded;
@@ -73,6 +74,10 @@
   function handleClearAll() {
     store.clearAll();
     expanded = false;
+  }
+
+  function handleClearShow(showId: number) {
+    store.clearShow(showId);
   }
 </script>
 
@@ -129,63 +134,98 @@
           </div>
         </div>
 
-        <!-- Cart items (scrollable) — extra pb to clear the bottom bar -->
+        <!-- Cart items (scrollable) -->
         <div class="flex-1 space-y-3 overflow-y-auto px-4 pb-20 sm:px-6 lg:px-8">
-          <!-- Assigned seats grouped by section -->
-          {#each Object.entries(groupedSeats) as [_sectionId, group] (_sectionId)}
-            <div class="rounded-xl bg-surface-container-low p-3">
-              <p class="mb-2 text-[11px] font-semibold tracking-wide text-primary uppercase">
-                {group.sectionName}
-              </p>
-              <div class="space-y-1.5">
-                {#each group.seats as seat (seat.id)}
-                  <div class="flex items-center justify-between gap-2">
-                    <div class="flex min-w-0 items-center gap-2">
-                      <span
-                        class="inline-flex h-6 items-center rounded-md bg-surface-container-highest px-2 text-[11px] font-semibold text-foreground"
-                      >
-                        {seat.label}
-                      </span>
-                    </div>
-                    <div class="flex shrink-0 items-center gap-2">
-                      <span class="text-xs font-semibold text-foreground">
-                        {formatPrice(seat.price)}
-                      </span>
-                      <button
-                        type="button"
-                        class="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                        onclick={() => handleRemoveSeat(seat.id)}
-                        title="Xóa ghế {seat.label}"
-                      >
-                        <X class="h-3.5 w-3.5" />
-                      </button>
+          {#each activeCarts as cart (cart.showId)}
+            {@const groupedSeats = groupSeatsBySection(cart)}
+            {@const generalEntries = getGeneralEntries(cart)}
+
+            <!-- Show card — wraps all tickets for this show -->
+            <div
+              class="overflow-hidden rounded-xl border {isMultiShow
+                ? 'border-primary/20'
+                : 'border-border/30'}"
+            >
+              <!-- Show header (always show if multi-show, compact if single) -->
+              {#if isMultiShow}
+                <div
+                  class="flex items-center justify-between border-b border-primary/10 bg-primary/5 px-3 py-2"
+                >
+                  <div class="flex items-center gap-2">
+                    <Calendar class="h-3.5 w-3.5 text-primary" />
+                    <span class="text-[11px] font-bold text-primary">
+                      {cart.showLabel}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    class="flex cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                    onclick={() => handleClearShow(cart.showId)}
+                    title="Xóa vé suất này"
+                  >
+                    <Trash2 class="h-3 w-3" />
+                  </button>
+                </div>
+              {/if}
+
+              <!-- Tickets content inside the show card -->
+              <div class="divide-y divide-border/20 bg-surface-container-low">
+                <!-- Assigned seats grouped by section -->
+                {#each Object.entries(groupedSeats) as [_sectionId, group] (_sectionId)}
+                  <div class="px-3 py-2.5">
+                    <p
+                      class="mb-1.5 text-[10px] font-semibold tracking-wide text-primary uppercase"
+                    >
+                      {group.sectionName}
+                    </p>
+                    <div class="space-y-1">
+                      {#each group.seats as seat (seat.id)}
+                        <div class="flex items-center justify-between gap-2">
+                          <span
+                            class="inline-flex h-5 items-center rounded bg-surface-container-highest px-1.5 text-[10px] font-semibold text-foreground"
+                          >
+                            {seat.label}
+                          </span>
+                          <div class="flex shrink-0 items-center gap-1.5">
+                            <span class="text-[11px] font-semibold text-foreground">
+                              {formatPrice(seat.price)}
+                            </span>
+                            <button
+                              type="button"
+                              class="flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                              onclick={() => handleRemoveSeat(seat.id)}
+                              title="Xóa ghế {seat.label}"
+                            >
+                              <X class="h-3 w-3" />
+                            </button>
+                          </div>
+                        </div>
+                      {/each}
                     </div>
                   </div>
                 {/each}
-              </div>
-            </div>
-          {/each}
 
-          <!-- General admission -->
-          {#each generalEntries as entry (entry.sectionId)}
-            <div class="rounded-xl bg-surface-container-low p-3">
-              <div class="flex items-center justify-between">
-                <div>
-                  <p class="text-[11px] font-semibold tracking-wide text-primary uppercase">
-                    {entry.sectionName}
-                  </p>
-                  <p class="mt-0.5 text-xs text-muted-foreground">Vé đứng × {entry.qty}</p>
-                </div>
-                <div class="flex items-center gap-2">
-                  <button
-                    type="button"
-                    class="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                    onclick={() => store.setGeneralQuantity(entry.sectionId, 0)}
-                    title="Xóa vé"
-                  >
-                    <X class="h-3.5 w-3.5" />
-                  </button>
-                </div>
+                <!-- General admission -->
+                {#each generalEntries as entry (entry.sectionId)}
+                  <div class="flex items-center justify-between px-3 py-2.5">
+                    <div>
+                      <p class="text-[10px] font-semibold tracking-wide text-primary uppercase">
+                        {entry.sectionName}
+                      </p>
+                      <p class="mt-0.5 text-[11px] text-muted-foreground">
+                        Vé đứng × {entry.qty}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      class="flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                      onclick={() => store.setGeneralQuantity(entry.sectionId, 0)}
+                      title="Xóa vé"
+                    >
+                      <X class="h-3 w-3" />
+                    </button>
+                  </div>
+                {/each}
               </div>
             </div>
           {/each}
@@ -206,7 +246,7 @@
         <div class="flex justify-center pt-2">
           <button
             type="button"
-            class="flex cursor-pointer flex-col items-center gap-0 opacity-50 transition-opacity hover:opacity-80"
+            class="flex w-full cursor-pointer flex-col items-center gap-0 opacity-50 transition-opacity hover:opacity-80 md:hidden"
             onclick={toggleExpand}
             aria-label="Mở giỏ vé"
           >
@@ -219,7 +259,16 @@
       <div
         class="mx-auto flex max-w-7xl items-center justify-between gap-4 border-b border-border/20 px-4 py-1.5 sm:px-6 lg:px-8"
       >
-        <span class="text-xs text-muted-foreground">Tổng cộng</span>
+        <div class="flex items-center gap-2">
+          <span class="text-xs text-muted-foreground">Tổng cộng</span>
+          {#if isMultiShow}
+            <span
+              class="rounded-full bg-primary/10 px-1.5 py-0.5 text-[9px] font-bold text-primary"
+            >
+              {activeCarts.length} suất
+            </span>
+          {/if}
+        </div>
         <span class="text-base font-extrabold text-foreground sm:text-lg">
           {formatPrice(store.totalPrice)}
         </span>
@@ -251,12 +300,16 @@
               {/if}
             </span>
             <p class="mt-0.5 truncate text-[11px] text-muted-foreground sm:text-xs">
-              Nhấn để xem chi tiết
+              {#if isMultiShow}
+                {activeCarts.length} suất diễn • Nhấn để xem chi tiết
+              {:else}
+                Nhấn để xem chi tiết
+              {/if}
             </p>
           </div>
           <!-- Up/Down toggle icon -->
           <div
-            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-container-high transition-colors"
+            class="hidden h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-container-high transition-colors md:flex"
           >
             {#if expanded}
               <ChevronDown class="h-4 w-4 text-foreground" />

--- a/src/lib/components/seat-map/SummaryBar.svelte
+++ b/src/lib/components/seat-map/SummaryBar.svelte
@@ -17,16 +17,18 @@
     store: SeatSelectionStore;
     onCheckout: () => void;
     maxTickets: number;
+    /** Whether the event has multiple shows (always show per-show grouping) */
+    multiShowEvent?: boolean;
   }
 
-  let { store, onCheckout, maxTickets }: Props = $props();
+  let { store, onCheckout, maxTickets, multiShowEvent = false }: Props = $props();
 
   let expanded = $state(false);
   let hasSelection = $derived(store.totalCount > 0);
 
   /** Get all active carts (carts with selections) */
   let activeCarts = $derived(store.getActiveCarts());
-  let isMultiShow = $derived(activeCarts.length > 1);
+  let isMultiShow = $derived(multiShowEvent || activeCarts.length > 1);
 
   /** Group selected assigned seats by section for a given cart */
   function groupSeatsBySection(cart: ShowCart) {
@@ -53,9 +55,10 @@
     for (const [sectionId, qty] of Object.entries(cart.generalQuantities)) {
       if (qty > 0) {
         const sid = Number(sectionId);
+        const name = store.getSectionName(cart.showId, sid) ?? `Khu vực #${sid}`;
         entries.push({
           sectionId: sid,
-          sectionName: `Khu vực #${sid}`,
+          sectionName: name,
           qty,
         });
       }

--- a/src/lib/components/seat-map/SummaryBar.svelte
+++ b/src/lib/components/seat-map/SummaryBar.svelte
@@ -70,8 +70,8 @@
     expanded = !expanded;
   }
 
-  function handleRemoveSeat(seatId: number) {
-    store.toggleSeat(seatId, '', 0, '', 0);
+  function handleRemoveSeat(showId: number, seatId: number) {
+    store.removeSeatFromShow(showId, seatId);
   }
 
   function handleClearAll() {
@@ -196,7 +196,7 @@
                             <button
                               type="button"
                               class="flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                              onclick={() => handleRemoveSeat(seat.id)}
+                              onclick={() => handleRemoveSeat(cart.showId, seat.id)}
                               title="Xóa ghế {seat.label}"
                             >
                               <X class="h-3 w-3" />
@@ -222,7 +222,8 @@
                     <button
                       type="button"
                       class="flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                      onclick={() => store.setGeneralQuantity(entry.sectionId, 0)}
+                      onclick={() =>
+                        store.setGeneralQuantityForShow(cart.showId, entry.sectionId, 0)}
                       title="Xóa vé"
                     >
                       <X class="h-3 w-3" />

--- a/src/lib/stores/seat-selection-store.svelte.ts
+++ b/src/lib/stores/seat-selection-store.svelte.ts
@@ -195,6 +195,12 @@ export function createSeatSelectionStore(maxTickets: number) {
     return cart ? cart.selectedSeats.map((s) => s.id) : [];
   }
 
+  /** Look up a section name by showId + sectionId */
+  function getSectionName(showId: number, sectionId: number): string | undefined {
+    const section = findSection(showId, sectionId);
+    return section?.name;
+  }
+
   /** Get all carts that have selections */
   function getActiveCarts(): ShowCart[] {
     return allCarts.filter(
@@ -255,6 +261,7 @@ export function createSeatSelectionStore(maxTickets: number) {
     clearAll,
     clearShow,
     getSelectedSeatIds,
+    getSectionName,
     getSummaryLabels,
   };
 }

--- a/src/lib/stores/seat-selection-store.svelte.ts
+++ b/src/lib/stores/seat-selection-store.svelte.ts
@@ -1,26 +1,90 @@
 // src/lib/stores/seat-selection-store.ts
 import type { SeatMapSection, SelectedSeat } from '$lib/types/seat-map';
 
+export interface ShowCart {
+  showId: number;
+  showLabel: string;
+  selectedSeats: SelectedSeat[];
+  generalQuantities: Record<number, number>;
+}
+
 export function createSeatSelectionStore(maxTickets: number) {
-  let selectedSeats = $state<SelectedSeat[]>([]);
-  let generalQuantities = $state<Record<number, number>>({});
+  /** All carts keyed by showId */
+  let carts = $state<Record<number, ShowCart>>({});
+
+  /** Sections keyed by showId — needed for price lookups across shows */
+  let sectionsMap = $state<Record<number, SeatMapSection[]>>({});
+
+  /** Currently active showId */
+  let activeShowId = $state<number>(0);
+
+  // ── Derived: current show's cart ──
+  const currentCart = $derived<ShowCart>(
+    carts[activeShowId] ?? {
+      showId: activeShowId,
+      showLabel: '',
+      selectedSeats: [],
+      generalQuantities: {},
+    },
+  );
+
+  // ── Derived: flatten all carts for total calculation ──
+  const allCarts = $derived<ShowCart[]>(Object.values(carts));
+
+  /** Find a section by id, searching the correct show's sections */
+  function findSection(showId: number, sectionId: number): SeatMapSection | undefined {
+    const sections = sectionsMap[showId];
+    return sections?.find((s) => s.id === sectionId);
+  }
 
   const totalPrice = $derived(
-    selectedSeats.reduce((sum, s) => sum + s.price, 0) +
-      Object.entries(generalQuantities).reduce((sum, [sectionId, qty]) => {
-        const section = sectionsRef.find((s) => s.id === Number(sectionId));
-        return sum + (section ? Number(section.price) * qty : 0);
-      }, 0),
+    allCarts.reduce((sum, cart) => {
+      const seatPrice = cart.selectedSeats.reduce((s, seat) => s + seat.price, 0);
+      const gaPrice = Object.entries(cart.generalQuantities).reduce((s, [sectionId, qty]) => {
+        const section = findSection(cart.showId, Number(sectionId));
+        return s + (section ? Number(section.price) * qty : 0);
+      }, 0);
+      return sum + seatPrice + gaPrice;
+    }, 0),
   );
 
   const totalCount = $derived(
-    selectedSeats.length + Object.values(generalQuantities).reduce((sum, qty) => sum + qty, 0),
+    allCarts.reduce((sum, cart) => {
+      const seatCount = cart.selectedSeats.length;
+      const gaCount = Object.values(cart.generalQuantities).reduce((s, qty) => s + qty, 0);
+      return sum + seatCount + gaCount;
+    }, 0),
   );
 
-  let sectionsRef: SeatMapSection[] = [];
+  // ── Current show totals (for max ticket enforcement per-show) ──
+  const currentShowCount = $derived(
+    currentCart.selectedSeats.length +
+      Object.values(currentCart.generalQuantities).reduce((s, qty) => s + qty, 0),
+  );
+
+  /** Get sections for the active show */
+  function getActiveSections(): SeatMapSection[] {
+    return sectionsMap[activeShowId] ?? [];
+  }
 
   function setSections(sections: SeatMapSection[]) {
-    sectionsRef = sections;
+    sectionsMap = { ...sectionsMap, [activeShowId]: sections };
+  }
+
+  function setActiveShow(showId: number, showLabel: string) {
+    activeShowId = showId;
+    // Ensure cart exists for this show
+    if (!carts[showId]) {
+      carts = {
+        ...carts,
+        [showId]: {
+          showId,
+          showLabel,
+          selectedSeats: [],
+          generalQuantities: {},
+        },
+      };
+    }
   }
 
   function toggleSeat(
@@ -30,69 +94,140 @@ export function createSeatSelectionStore(maxTickets: number) {
     sectionName: string,
     price: number,
   ) {
-    const idx = selectedSeats.findIndex((s) => s.id === seatId);
+    const cart = carts[activeShowId];
+    if (!cart) return false;
+
+    const idx = cart.selectedSeats.findIndex((s) => s.id === seatId);
     if (idx >= 0) {
-      selectedSeats = selectedSeats.filter((s) => s.id !== seatId);
+      // Remove seat
+      carts = {
+        ...carts,
+        [activeShowId]: {
+          ...cart,
+          selectedSeats: cart.selectedSeats.filter((s) => s.id !== seatId),
+        },
+      };
     } else {
       if (maxTickets > 0 && totalCount >= maxTickets) return false;
-      selectedSeats = [...selectedSeats, { id: seatId, label, sectionId, sectionName, price }];
+      carts = {
+        ...carts,
+        [activeShowId]: {
+          ...cart,
+          selectedSeats: [
+            ...cart.selectedSeats,
+            { id: seatId, label, sectionId, sectionName, price },
+          ],
+        },
+      };
     }
     return true;
   }
 
   function isSeatSelected(seatId: number): boolean {
-    return selectedSeats.some((s) => s.id === seatId);
+    const cart = carts[activeShowId];
+    return cart ? cart.selectedSeats.some((s) => s.id === seatId) : false;
   }
 
   function setGeneralQuantity(sectionId: number, qty: number) {
-    const currentAssigned = selectedSeats.length;
-    const otherGeneral = Object.entries(generalQuantities)
+    const cart = carts[activeShowId];
+    if (!cart) return;
+
+    const currentAssigned = cart.selectedSeats.length;
+    const otherGeneral = Object.entries(cart.generalQuantities)
       .filter(([id]) => Number(id) !== sectionId)
       .reduce((sum, [, q]) => sum + q, 0);
 
-    if (maxTickets > 0 && currentAssigned + otherGeneral + qty > maxTickets) {
-      qty = maxTickets - currentAssigned - otherGeneral;
+    // Also account for other shows' selections against global max
+    const otherShowsCount = allCarts
+      .filter((c) => c.showId !== activeShowId)
+      .reduce(
+        (sum, c) =>
+          sum +
+          c.selectedSeats.length +
+          Object.values(c.generalQuantities).reduce((s, q) => s + q, 0),
+        0,
+      );
+
+    if (maxTickets > 0 && otherShowsCount + currentAssigned + otherGeneral + qty > maxTickets) {
+      qty = maxTickets - otherShowsCount - currentAssigned - otherGeneral;
     }
 
     if (qty <= 0) {
-      const { [sectionId]: _removed, ...rest } = generalQuantities;
+      const { [sectionId]: _removed, ...rest } = cart.generalQuantities;
       void _removed;
-      generalQuantities = rest;
+      carts = {
+        ...carts,
+        [activeShowId]: { ...cart, generalQuantities: rest },
+      };
     } else {
-      generalQuantities = { ...generalQuantities, [sectionId]: qty };
+      carts = {
+        ...carts,
+        [activeShowId]: {
+          ...cart,
+          generalQuantities: { ...cart.generalQuantities, [sectionId]: qty },
+        },
+      };
     }
   }
 
   function getGeneralQuantity(sectionId: number): number {
-    return generalQuantities[sectionId] ?? 0;
+    const cart = carts[activeShowId];
+    return cart ? (cart.generalQuantities[sectionId] ?? 0) : 0;
   }
 
   function clearAll() {
-    selectedSeats = [];
-    generalQuantities = {};
+    carts = {};
+    sectionsMap = {};
+  }
+
+  function clearShow(showId: number) {
+    const { [showId]: _removedCart, ...restCarts } = carts;
+    void _removedCart;
+    carts = restCarts;
+
+    const { [showId]: _removedSections, ...restSections } = sectionsMap;
+    void _removedSections;
+    sectionsMap = restSections;
   }
 
   function getSelectedSeatIds(): number[] {
-    return selectedSeats.map((s) => s.id);
+    const cart = carts[activeShowId];
+    return cart ? cart.selectedSeats.map((s) => s.id) : [];
+  }
+
+  /** Get all carts that have selections */
+  function getActiveCarts(): ShowCart[] {
+    return allCarts.filter(
+      (cart) =>
+        cart.selectedSeats.length > 0 || Object.values(cart.generalQuantities).some((q) => q > 0),
+    );
   }
 
   function getSummaryLabels(): string {
-    const seatLabels = selectedSeats.map((s) => s.label);
-    const gaLabels = Object.entries(generalQuantities)
-      .filter(([, qty]) => qty > 0)
-      .map(([sectionId, qty]) => {
-        const section = sectionsRef.find((s) => s.id === Number(sectionId));
-        return section ? `${section.name} x${qty}` : `GA x${qty}`;
-      });
-    return [...seatLabels, ...gaLabels].join(', ');
+    const activeCarts = getActiveCarts();
+    const labels: string[] = [];
+    for (const cart of activeCarts) {
+      const seatLabels = cart.selectedSeats.map((s) => s.label);
+      const gaLabels = Object.entries(cart.generalQuantities)
+        .filter(([, qty]) => qty > 0)
+        .map(([sectionId, qty]) => {
+          const section = findSection(cart.showId, Number(sectionId));
+          return section ? `${section.name} x${qty}` : `GA x${qty}`;
+        });
+      const showItems = [...seatLabels, ...gaLabels].join(', ');
+      if (showItems) {
+        labels.push(activeCarts.length > 1 ? `[${cart.showLabel}] ${showItems}` : showItems);
+      }
+    }
+    return labels.join(' | ');
   }
 
   return {
     get selectedSeats() {
-      return selectedSeats;
+      return currentCart.selectedSeats;
     },
     get generalQuantities() {
-      return generalQuantities;
+      return currentCart.generalQuantities;
     },
     get totalPrice() {
       return totalPrice;
@@ -100,12 +235,25 @@ export function createSeatSelectionStore(maxTickets: number) {
     get totalCount() {
       return totalCount;
     },
+    get currentShowCount() {
+      return currentShowCount;
+    },
+    get activeShowId() {
+      return activeShowId;
+    },
+    get carts() {
+      return carts;
+    },
+    getActiveCarts,
+    getActiveSections,
     setSections,
+    setActiveShow,
     toggleSeat,
     isSeatSelected,
     setGeneralQuantity,
     getGeneralQuantity,
     clearAll,
+    clearShow,
     getSelectedSeatIds,
     getSummaryLabels,
   };

--- a/src/lib/stores/seat-selection-store.svelte.ts
+++ b/src/lib/stores/seat-selection-store.svelte.ts
@@ -62,6 +62,12 @@ export function createSeatSelectionStore(maxTickets: number) {
       Object.values(currentCart.generalQuantities).reduce((s, qty) => s + qty, 0),
   );
 
+  /** Whether the global ticket limit has been reached */
+  const isAtLimit = $derived(maxTickets > 0 && totalCount >= maxTickets);
+
+  /** How many more tickets the user can add */
+  const remainingTickets = $derived(maxTickets > 0 ? maxTickets - totalCount : Infinity);
+
   /** Get sections for the active show */
   function getActiveSections(): SeatMapSection[] {
     return sectionsMap[activeShowId] ?? [];
@@ -313,6 +319,15 @@ export function createSeatSelectionStore(maxTickets: number) {
     },
     get carts() {
       return carts;
+    },
+    get isAtLimit() {
+      return isAtLimit;
+    },
+    get remainingTickets() {
+      return remainingTickets;
+    },
+    get maxTickets() {
+      return maxTickets;
     },
     getActiveCarts,
     getActiveSections,

--- a/src/lib/stores/seat-selection-store.svelte.ts
+++ b/src/lib/stores/seat-selection-store.svelte.ts
@@ -176,18 +176,40 @@ export function createSeatSelectionStore(maxTickets: number) {
   }
 
   function clearAll() {
-    carts = {};
-    sectionsMap = {};
+    // Preserve the active show's cart (empty) and sections so seat selection continues to work
+    const activeCart = carts[activeShowId];
+    const activeSections = sectionsMap[activeShowId];
+    carts = activeCart
+      ? {
+          [activeShowId]: {
+            ...activeCart,
+            selectedSeats: [],
+            generalQuantities: {},
+          },
+        }
+      : {};
+    sectionsMap = activeSections ? { [activeShowId]: activeSections } : {};
   }
 
   function clearShow(showId: number) {
-    const { [showId]: _removedCart, ...restCarts } = carts;
-    void _removedCart;
-    carts = restCarts;
+    if (showId === activeShowId) {
+      // Keep the cart entry but empty it, preserve sections for continued interaction
+      const cart = carts[showId];
+      if (cart) {
+        carts = {
+          ...carts,
+          [showId]: { ...cart, selectedSeats: [], generalQuantities: {} },
+        };
+      }
+    } else {
+      const { [showId]: _removedCart, ...restCarts } = carts;
+      void _removedCart;
+      carts = restCarts;
 
-    const { [showId]: _removedSections, ...restSections } = sectionsMap;
-    void _removedSections;
-    sectionsMap = restSections;
+      const { [showId]: _removedSections, ...restSections } = sectionsMap;
+      void _removedSections;
+      sectionsMap = restSections;
+    }
   }
 
   function getSelectedSeatIds(): number[] {
@@ -199,6 +221,42 @@ export function createSeatSelectionStore(maxTickets: number) {
   function getSectionName(showId: number, sectionId: number): string | undefined {
     const section = findSection(showId, sectionId);
     return section?.name;
+  }
+
+  /** Remove a specific seat from a specific show's cart (for cross-show removal in summary) */
+  function removeSeatFromShow(showId: number, seatId: number) {
+    const cart = carts[showId];
+    if (!cart) return;
+    carts = {
+      ...carts,
+      [showId]: {
+        ...cart,
+        selectedSeats: cart.selectedSeats.filter((s) => s.id !== seatId),
+      },
+    };
+  }
+
+  /** Set general admission quantity for a specific show's cart */
+  function setGeneralQuantityForShow(showId: number, sectionId: number, qty: number) {
+    const cart = carts[showId];
+    if (!cart) return;
+
+    if (qty <= 0) {
+      const { [sectionId]: _removed, ...rest } = cart.generalQuantities;
+      void _removed;
+      carts = {
+        ...carts,
+        [showId]: { ...cart, generalQuantities: rest },
+      };
+    } else {
+      carts = {
+        ...carts,
+        [showId]: {
+          ...cart,
+          generalQuantities: { ...cart.generalQuantities, [sectionId]: qty },
+        },
+      };
+    }
   }
 
   /** Get all carts that have selections */
@@ -262,6 +320,8 @@ export function createSeatSelectionStore(maxTickets: number) {
     clearShow,
     getSelectedSeatIds,
     getSectionName,
+    removeSeatFromShow,
+    setGeneralQuantityForShow,
     getSummaryLabels,
   };
 }

--- a/src/lib/stores/seat-selection-store.svelte.ts
+++ b/src/lib/stores/seat-selection-store.svelte.ts
@@ -248,10 +248,33 @@ export function createSeatSelectionStore(maxTickets: number) {
     };
   }
 
-  /** Set general admission quantity for a specific show's cart */
+  /** Set general admission quantity for a specific show's cart (with global limit enforcement) */
   function setGeneralQuantityForShow(showId: number, sectionId: number, qty: number) {
     const cart = carts[showId];
     if (!cart) return;
+
+    // Enforce global maxTickets limit (same logic as setGeneralQuantity)
+    if (maxTickets > 0 && qty > 0) {
+      const currentAssigned = cart.selectedSeats.length;
+      const otherGeneral = Object.entries(cart.generalQuantities)
+        .filter(([id]) => Number(id) !== sectionId)
+        .reduce((sum, [, q]) => sum + q, 0);
+
+      const otherShowsCount = allCarts
+        .filter((c) => c.showId !== showId)
+        .reduce(
+          (sum, c) =>
+            sum +
+            c.selectedSeats.length +
+            Object.values(c.generalQuantities).reduce((s, q) => s + q, 0),
+          0,
+        );
+
+      const available = maxTickets - otherShowsCount - currentAssigned - otherGeneral;
+      if (qty > available) {
+        qty = available;
+      }
+    }
 
     if (qty <= 0) {
       const { [sectionId]: _removed, ...rest } = cart.generalQuantities;

--- a/src/lib/stores/seat-selection-store.svelte.ts
+++ b/src/lib/stores/seat-selection-store.svelte.ts
@@ -84,6 +84,12 @@ export function createSeatSelectionStore(maxTickets: number) {
           generalQuantities: {},
         },
       };
+    } else if (showLabel && carts[showId].showLabel !== showLabel) {
+      // Refresh the label if it changed (e.g. fallback → real formatted label)
+      carts = {
+        ...carts,
+        [showId]: { ...carts[showId], showLabel },
+      };
     }
   }
 

--- a/src/lib/stores/toast.ts
+++ b/src/lib/stores/toast.ts
@@ -9,7 +9,7 @@ export interface Toast {
   duration: number;
 }
 
-const MAX_TOASTS = 6;
+const MAX_TOASTS = 5;
 
 function createToastStore() {
   const { subscribe, update } = writable<Toast[]>([]);

--- a/src/lib/utils/datetime.ts
+++ b/src/lib/utils/datetime.ts
@@ -93,11 +93,13 @@ export function to12Hour(h24: number): { hour: string; period: 'AM' | 'PM' } {
   return { hour: String(h24 - 12), period: 'PM' };
 }
 
+const TZ = 'Asia/Ho_Chi_Minh';
+
 /** Format a date string or Date object to "Thứ Hai, 14 tháng 4, 2025" in Vietnamese locale */
 export function formatDate(dateStr: string | Date): string {
   const d = new Date(dateStr);
   return new Intl.DateTimeFormat('vi-VN', {
-    timeZone: 'Asia/Ho_Chi_Minh',
+    timeZone: TZ,
     weekday: 'short',
     day: 'numeric',
     month: 'short',
@@ -110,6 +112,28 @@ export const formatTime = (dateStr: string) => {
   return new Date(dateStr).toLocaleTimeString('vi-VN', {
     hour: '2-digit',
     minute: '2-digit',
-    timeZone: 'Asia/Ho_Chi_Minh',
+    timeZone: TZ,
   });
 };
+
+/** Format a date string to short form like "T7, 14 THG 4" pinned to Asia/Ho_Chi_Minh */
+export function formatShortDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return new Intl.DateTimeFormat('vi-VN', {
+    timeZone: TZ,
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  })
+    .format(d)
+    .toUpperCase();
+}
+
+/** Extract the day-of-month number pinned to Asia/Ho_Chi_Minh timezone */
+export function getDayInTZ(dateStr: string): string {
+  const d = new Date(dateStr);
+  return new Intl.DateTimeFormat('vi-VN', {
+    timeZone: TZ,
+    day: 'numeric',
+  }).format(d);
+}

--- a/src/routes/(auth)/login/+page.svelte
+++ b/src/routes/(auth)/login/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto, invalidateAll } from '$app/navigation';
+  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { Button } from '$lib/components/ui/button';
@@ -58,15 +58,14 @@
 
     if (!error && data) {
       toast.success('Đăng nhập thành công!');
-      await invalidateAll();
 
       const redirectTo = page.url.searchParams.get('redirect');
       if (redirectTo && redirectTo.startsWith('/')) {
-        goto(resolve(redirectTo));
+        goto(resolve(redirectTo), { invalidateAll: true });
       } else if (data.role === 'admin') {
-        goto(resolve('/admin'));
+        goto(resolve('/admin'), { invalidateAll: true });
       } else {
-        goto(resolve('/'));
+        goto(resolve('/'), { invalidateAll: true });
       }
     }
   }

--- a/src/routes/(customer)/events/[id]/+page.svelte
+++ b/src/routes/(customer)/events/[id]/+page.svelte
@@ -102,10 +102,11 @@
   }
 
   function handleBuyTicket(showId: number) {
+    const seatsPath = resolve(`/events/${event.id}/shows/${showId}/seats`);
     if (!user) {
-      goto(resolve(`/login?redirect=/events/${event.id}`));
+      goto(resolve(`/login?redirect=${encodeURIComponent(seatsPath)}`));
     } else {
-      goto(resolve(`/events/${event.id}/shows/${showId}/seats`));
+      goto(seatsPath);
     }
   }
 
@@ -345,14 +346,17 @@
                     {#each visibleShows as show (show.id)}
                       {@const isActive = activeShow?.id === show.id}
                       {@const available = show.sections.reduce(
-                        (sum, s) => sum + getAvailable(s),
+                        (sum: number, s: EventDetailSection) => sum + getAvailable(s),
                         0,
                       )}
-                      {@const total = show.sections.reduce((sum, s) => sum + getTotal(s), 0)}
+                      {@const total = show.sections.reduce(
+                        (sum: number, s: EventDetailSection) => sum + getTotal(s),
+                        0,
+                      )}
                       {@const avail = getAvailabilityLabel(available, total)}
                       <button
                         onclick={() => selectShow(show.id)}
-                        class="flex min-w-[150px] shrink-0 cursor-pointer flex-col items-center gap-2 rounded-xl p-5 transition-all duration-300 {isActive
+                        class="flex min-w-37.5 shrink-0 cursor-pointer flex-col items-center gap-2 rounded-xl p-5 transition-all duration-300 {isActive
                           ? 'scale-105 bg-primary-container text-white shadow-lg ring-4 ring-primary-container/20'
                           : 'bg-surface-container text-foreground hover:bg-surface-container-high active:scale-95'}"
                       >
@@ -451,7 +455,7 @@
                   <div class="rounded-xl bg-surface pb-1">
                     <button
                       onclick={() => handleBuyTicket(activeShow!.id)}
-                      class="flex w-full cursor-pointer items-center justify-center gap-3 rounded-full bg-gradient-to-br from-primary to-primary-container px-8 py-5 text-lg font-bold text-white shadow-xl shadow-primary/20 transition-all duration-300 hover:scale-[1.02] active:scale-95"
+                      class="flex w-full cursor-pointer items-center justify-center gap-3 rounded-full bg-linear-to-br from-primary to-primary-container px-8 py-5 text-lg font-bold text-white shadow-xl shadow-primary/20 transition-all duration-300 hover:scale-[1.02] active:scale-95"
                     >
                       Tiếp tục chọn chỗ
                       <ArrowRight class="h-5 w-5" />
@@ -484,7 +488,7 @@
                         >
                           <!-- Dot -->
                           <div
-                            class="absolute top-0 -left-[9px] h-4 w-4 rounded-full {isFirst
+                            class="absolute top-0 -left-2.25 h-4 w-4 rounded-full {isFirst
                               ? 'bg-primary'
                               : 'bg-surface-container-highest'} ring-4 ring-background"
                           ></div>

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.server.ts
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.server.ts
@@ -1,5 +1,5 @@
-import { seatService } from '$lib/server/services/seat.service';
 import { eventService } from '$lib/server/services/event.service';
+import { seatService } from '$lib/server/services/seat.service';
 import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -28,6 +28,17 @@ export const load: PageServerLoad = async ({ params, locals }) => {
       error(404, 'Không tìm thấy suất diễn');
     }
 
+    // Build list of all published shows for the show switcher
+    const allShows = event.shows
+      .filter((s) => s.status === 'published' || user.role === 'admin')
+      .map((s) => ({
+        id: s.id,
+        title: s.title,
+        show_date: s.show_date,
+        start_time: s.start_time,
+        end_time: s.end_time,
+      }));
+
     return {
       event: {
         id: event.id,
@@ -44,6 +55,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
         start_time: show.start_time,
         end_time: show.end_time,
       },
+      allShows,
       seatMap,
     };
   } catch (err: unknown) {

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { goto, replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
   import SeatMap from '$lib/components/seat-map/SeatMap.svelte';
   import SummaryBar from '$lib/components/seat-map/SummaryBar.svelte';
@@ -8,6 +8,7 @@
   import { api } from '$lib/utils/api';
   import { formatDate, formatShortDate, formatTime, getDayInTZ } from '$lib/utils/datetime';
   import { ArrowLeft, Calendar, ChevronDown, Clock, LoaderCircle } from 'lucide-svelte';
+  import { onDestroy } from 'svelte';
   import { SvelteURLSearchParams } from 'svelte/reactivity';
   import { fly } from 'svelte/transition';
 
@@ -137,9 +138,9 @@
         store.setActiveShow(showId, label);
         store.setSections(res.data.sections);
 
-        // Update URL without full navigation
-        const newUrl = `/events/${data.event.id}/shows/${showId}/seats`;
-        history.replaceState(history.state, '', newUrl);
+        // Update URL without full navigation (respects paths.base)
+        const newUrl = resolve(`/events/${data.event.id}/shows/${showId}/seats`);
+        replaceState(newUrl, {});
       }
     } catch (error) {
       // Ignore abort errors, they are expected when switching shows rapidly
@@ -156,9 +157,21 @@
     }
   }
 
+  function abortPendingRequest() {
+    if (activeAbortController) {
+      activeAbortController.abort();
+      activeAbortController = null;
+      isLoadingSeatMap = false;
+    }
+  }
+
   function goBack() {
+    abortPendingRequest();
     goto(resolve(`/events/${data.event.id}`));
   }
+
+  // Abort any in-flight request when the component is destroyed
+  onDestroy(abortPendingRequest);
 
   function handleCheckout() {
     const activeCarts = store.getActiveCarts();

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
@@ -313,5 +313,10 @@
   {/if}
 
   <!-- Sticky summary bar -->
-  <SummaryBar {store} onCheckout={handleCheckout} maxTickets={event.max_tickets_per_user} />
+  <SummaryBar
+    {store}
+    onCheckout={handleCheckout}
+    maxTickets={event.max_tickets_per_user}
+    multiShowEvent={allShows.length > 1}
+  />
 </div>

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
@@ -5,9 +5,19 @@
   import SummaryBar from '$lib/components/seat-map/SummaryBar.svelte';
   import { createSeatSelectionStore } from '$lib/stores/seat-selection-store.svelte';
   import type { MapConfig, SeatMapData, StageElement } from '$lib/types/seat-map';
+  import { api } from '$lib/utils/api';
   import { formatDate, formatTime } from '$lib/utils/datetime';
-  import { ArrowLeft } from 'lucide-svelte';
+  import { ArrowLeft, Calendar, ChevronDown, Clock, Loader2 } from 'lucide-svelte';
   import { SvelteURLSearchParams } from 'svelte/reactivity';
+  import { fly } from 'svelte/transition';
+
+  interface ShowInfo {
+    id: number;
+    title: string | null;
+    show_date: string;
+    start_time: string;
+    end_time: string | null;
+  }
 
   interface PageData {
     event: {
@@ -18,60 +28,141 @@
       map_config: MapConfig;
       stage_layout: StageElement[];
     };
-    show: {
-      id: number;
-      title: string | null;
-      show_date: string;
-      start_time: string;
-      end_time: string | null;
-    };
+    show: ShowInfo;
+    allShows: ShowInfo[];
     seatMap: SeatMapData;
   }
 
   let { data } = $props<{ data: PageData }>();
 
   let event = $derived(data.event);
-  let show = $derived(data.show);
-  let seatMap = $derived(data.seatMap);
+  let allShows = $derived(data.allShows);
 
   let mapConfig = $derived<MapConfig>(data.event.map_config ?? { width: 1200, height: 800 });
-
   let stageLayout = $derived<StageElement[]>(
     Array.isArray(data.event.stage_layout) ? data.event.stage_layout : [],
   );
 
-  let store = createSeatSelectionStore(data.event.max_tickets_per_user);
+  // ── Current show & seat map state ──
+  let currentShowId = $state(0);
+  let seatMap = $state<SeatMapData>({ show_id: 0, sections: [] });
+  let isLoadingSeatMap = $state(false);
+  let showPickerOpen = $state(false);
+  let initialized = $state(false);
 
-  // Initialize sections ref when seatMap changes
+  let currentShow = $derived<ShowInfo>(
+    allShows.find((s: ShowInfo) => s.id === currentShowId) ?? data.show,
+  );
+
+  // ── Store ──
+  const getMaxTicketsPerUser = () => data.event.max_tickets_per_user;
+  let store = createSeatSelectionStore(getMaxTicketsPerUser());
+
+  // Initialize once from server data
   $effect(() => {
-    store.setSections(seatMap.sections);
+    if (initialized) return;
+    const showId = data.show.id;
+    const mapData = data.seatMap;
+    if (!showId || !mapData) return;
+
+    initialized = true;
+    currentShowId = showId;
+    seatMap = mapData;
+
+    const show = allShows.find((s: ShowInfo) => s.id === showId);
+    const label = show ? getShowLabel(show) : `Suất #${showId}`;
+    store.setActiveShow(showId, label);
+    store.setSections(mapData.sections);
   });
+
+  function getShowLabel(show: ShowInfo): string {
+    return show.title || `${formatTime(show.start_time)}, ${formatDate(show.show_date)}`;
+  }
+
+  function formatShortDate(dateStr: string): string {
+    const d = new Date(dateStr);
+    return new Intl.DateTimeFormat('vi-VN', {
+      timeZone: 'Asia/Ho_Chi_Minh',
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+    })
+      .format(d)
+      .toUpperCase();
+  }
+
+  async function switchShow(showId: number) {
+    if (showId === currentShowId) {
+      showPickerOpen = false;
+      return;
+    }
+
+    showPickerOpen = false;
+    isLoadingSeatMap = true;
+
+    try {
+      const res = await api.get<SeatMapData>(`/events/${data.event.id}/shows/${showId}/seats`);
+
+      if (res.data) {
+        currentShowId = showId;
+        seatMap = res.data;
+
+        const show = allShows.find((s: ShowInfo) => s.id === showId);
+        const label = show ? getShowLabel(show) : `Suất #${showId}`;
+        store.setActiveShow(showId, label);
+        store.setSections(res.data.sections);
+
+        // Update URL without full navigation
+        const newUrl = `/events/${data.event.id}/shows/${showId}/seats`;
+        history.replaceState(history.state, '', newUrl);
+      }
+    } catch {
+      // Error already handled by api utility
+    } finally {
+      isLoadingSeatMap = false;
+    }
+  }
 
   function goBack() {
     goto(resolve(`/events/${data.event.id}`));
   }
 
   function handleCheckout() {
-    const seatIds = store.getSelectedSeatIds();
-    const generalQty = store.generalQuantities;
+    const activeCarts = store.getActiveCarts();
+    if (activeCarts.length === 0) return;
 
     const params = new SvelteURLSearchParams();
-    if (seatIds.length > 0) {
-      params.set('seats', seatIds.join(','));
-    }
-    for (const [sectionId, qty] of Object.entries(generalQty)) {
-      if (qty > 0) {
-        params.set(`ga_${sectionId}`, String(qty));
+
+    // Build params for each show's cart
+    for (const cart of activeCarts) {
+      const seatIds = cart.selectedSeats.map((s: { id: number }) => s.id);
+      if (seatIds.length > 0) {
+        params.set(`seats_${cart.showId}`, seatIds.join(','));
+      }
+      for (const [sectionId, qty] of Object.entries(cart.generalQuantities)) {
+        if ((qty as number) > 0) {
+          params.set(`ga_${cart.showId}_${sectionId}`, String(qty));
+        }
       }
     }
-    params.set('show_id', String(data.show.id));
+
+    const showIds = activeCarts.map((c: { showId: number }) => c.showId).join(',');
+    params.set('shows', showIds);
 
     goto(resolve(`/events/${data.event.id}/checkout?${params.toString()}`));
   }
 
-  let showTitle = $derived(
-    show.title || `${formatTime(show.start_time)}, ${formatDate(show.show_date)}`,
-  );
+  let showTitle = $derived(getShowLabel(currentShow));
+
+  // Check if a show has items in the cart
+  function showHasItems(showId: number): boolean {
+    const cart = store.carts[showId];
+    if (!cart) return false;
+    return (
+      cart.selectedSeats.length > 0 ||
+      Object.values(cart.generalQuantities).some((q: number) => q > 0)
+    );
+  }
 </script>
 
 <svelte:head>
@@ -103,10 +194,123 @@
     </div>
   </header>
 
-  <!-- Main content -->
-  <main class="mx-auto max-w-7xl px-4 pt-4 sm:px-6 lg:px-8">
-    <SeatMap sections={seatMap.sections} {mapConfig} {stageLayout} {store} />
-  </main>
+  <!-- Show Switcher (only if multiple shows) -->
+  {#if allShows.length > 1}
+    <div
+      class="relative z-20 border-b border-border/20 bg-surface-container-lowest/70 backdrop-blur-sm"
+    >
+      <div class="mx-auto max-w-7xl px-4 py-2 sm:px-6 lg:px-8">
+        <div class="relative z-20">
+          <!-- Trigger button -->
+          <button
+            type="button"
+            class="flex w-full cursor-pointer items-center justify-between rounded-xl border border-border/40 bg-surface-container-low px-4 py-2.5 transition-colors hover:bg-surface-container-high"
+            onclick={() => (showPickerOpen = !showPickerOpen)}
+          >
+            <div class="flex items-center gap-3">
+              <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+                <Calendar class="h-4 w-4 text-primary" />
+              </div>
+              <div class="text-left">
+                <p class="text-xs font-semibold text-foreground">
+                  {formatShortDate(currentShow.show_date)} • {formatTime(currentShow.start_time)}
+                </p>
+                <p class="text-[10px] text-muted-foreground">
+                  Nhấn để chuyển suất diễn ({allShows.length} suất)
+                </p>
+              </div>
+            </div>
+            <ChevronDown
+              class="h-4 w-4 text-muted-foreground transition-transform {showPickerOpen
+                ? 'rotate-180'
+                : ''}"
+            />
+          </button>
+
+          <!-- Dropdown -->
+          {#if showPickerOpen}
+            <!-- Backdrop -->
+            <button
+              class="fixed inset-0 z-30 bg-transparent"
+              onclick={() => (showPickerOpen = false)}
+              aria-label="Đóng"
+            ></button>
+
+            <div
+              class="absolute right-0 left-0 z-40 mt-1 overflow-hidden rounded-xl border border-border/40 bg-surface-container-lowest shadow-xl"
+              transition:fly={{ y: -8, duration: 200 }}
+            >
+              <div class="max-h-64 overflow-y-auto p-1.5">
+                {#each allShows as show (show.id)}
+                  {@const isActive = show.id === currentShowId}
+                  {@const hasItems = showHasItems(show.id)}
+                  <button
+                    type="button"
+                    class="my-0.5 flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors {isActive
+                      ? 'bg-primary/10 ring-1 ring-primary/30'
+                      : 'hover:bg-surface-container-high'}"
+                    onclick={() => switchShow(show.id)}
+                  >
+                    <div
+                      class="flex h-10 w-10 shrink-0 flex-col items-center justify-center rounded-lg {isActive
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-surface-container-high text-foreground'}"
+                    >
+                      <span class="text-[9px] leading-tight font-bold uppercase">
+                        {formatShortDate(show.show_date).split(',')[0]?.trim() ?? ''}
+                      </span>
+                      <span class="text-xs leading-tight font-bold">
+                        {new Date(show.show_date).getDate()}
+                      </span>
+                    </div>
+                    <div class="min-w-0 flex-1">
+                      <p class="text-xs font-semibold text-foreground">
+                        {show.title || formatShortDate(show.show_date)}
+                      </p>
+                      <div class="flex items-center gap-2">
+                        <div class="flex items-center gap-1 text-[10px] text-muted-foreground">
+                          <Clock class="h-3 w-3" />
+                          {formatTime(show.start_time)}
+                          {#if show.end_time}
+                            – {formatTime(show.end_time)}
+                          {/if}
+                        </div>
+                        {#if hasItems}
+                          <span
+                            class="rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-bold text-primary"
+                          >
+                            Có vé trong giỏ
+                          </span>
+                        {/if}
+                      </div>
+                    </div>
+                    {#if isActive}
+                      <div class="h-2 w-2 shrink-0 rounded-full bg-primary"></div>
+                    {/if}
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Loading overlay -->
+  {#if isLoadingSeatMap}
+    <div class="flex items-center justify-center py-20">
+      <div class="flex flex-col items-center gap-3">
+        <Loader2 class="h-8 w-8 animate-spin text-primary" />
+        <p class="text-sm text-muted-foreground">Đang tải sơ đồ ghế...</p>
+      </div>
+    </div>
+  {:else}
+    <!-- Main content -->
+    <main class="mx-auto max-w-7xl px-4 pt-4 sm:px-6 lg:px-8">
+      <SeatMap sections={seatMap.sections} {mapConfig} {stageLayout} {store} />
+    </main>
+  {/if}
 
   <!-- Sticky summary bar -->
   <SummaryBar {store} onCheckout={handleCheckout} maxTickets={event.max_tickets_per_user} />

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
@@ -6,8 +6,8 @@
   import { createSeatSelectionStore } from '$lib/stores/seat-selection-store.svelte';
   import type { MapConfig, SeatMapData, StageElement } from '$lib/types/seat-map';
   import { api } from '$lib/utils/api';
-  import { formatDate, formatTime } from '$lib/utils/datetime';
-  import { ArrowLeft, Calendar, ChevronDown, Clock, Loader2 } from 'lucide-svelte';
+  import { formatDate, formatShortDate, formatTime, getDayInTZ } from '$lib/utils/datetime';
+  import { ArrowLeft, Calendar, ChevronDown, Clock, LoaderCircle } from 'lucide-svelte';
   import { SvelteURLSearchParams } from 'svelte/reactivity';
   import { fly } from 'svelte/transition';
 
@@ -48,7 +48,9 @@
   let seatMap = $state<SeatMapData>({ show_id: 0, sections: [] });
   let isLoadingSeatMap = $state(false);
   let showPickerOpen = $state(false);
-  let initialized = $state(false);
+
+  /** Track the last event+show combo we synced from server data */
+  let lastSyncedKey = $state('');
 
   let currentShow = $derived<ShowInfo>(
     allShows.find((s: ShowInfo) => s.id === currentShowId) ?? data.show,
@@ -58,16 +60,29 @@
   const getMaxTicketsPerUser = () => data.event.max_tickets_per_user;
   let store = createSeatSelectionStore(getMaxTicketsPerUser());
 
-  // Initialize once from server data
+  // Sync from server data whenever the route's event/show changes
+  // (handles initial load AND SvelteKit reusing this page for a different route)
   $effect(() => {
-    if (initialized) return;
+    const syncKey = `${data.event.id}-${data.show.id}`;
+    if (syncKey === lastSyncedKey) return;
+
     const showId = data.show.id;
     const mapData = data.seatMap;
     if (!showId || !mapData) return;
 
-    initialized = true;
+    lastSyncedKey = syncKey;
     currentShowId = showId;
     seatMap = mapData;
+
+    // Abort any in-flight show switch
+    if (activeAbortController) {
+      activeAbortController.abort();
+      activeAbortController = null;
+      isLoadingSeatMap = false;
+    }
+
+    // Reset the store for a fresh event
+    store.clearAll();
 
     const show = allShows.find((s: ShowInfo) => s.id === showId);
     const label = show ? getShowLabel(show) : `Suất #${showId}`;
@@ -79,24 +94,19 @@
     return show.title || `${formatTime(show.start_time)}, ${formatDate(show.show_date)}`;
   }
 
-  function formatShortDate(dateStr: string): string {
-    const d = new Date(dateStr);
-    return new Intl.DateTimeFormat('vi-VN', {
-      timeZone: 'Asia/Ho_Chi_Minh',
-      weekday: 'short',
-      day: 'numeric',
-      month: 'short',
-    })
-      .format(d)
-      .toUpperCase();
-  }
-
   // Track active request to prevent stale responses
   let activeAbortController: AbortController | null = null;
 
   async function switchShow(showId: number) {
     if (showId === currentShowId) {
       showPickerOpen = false;
+      // If a switch to another show is still in flight, abort it so
+      // the UI stays on the show the user just confirmed.
+      if (activeAbortController) {
+        activeAbortController.abort();
+        activeAbortController = null;
+        isLoadingSeatMap = false;
+      }
       return;
     }
 
@@ -283,7 +293,7 @@
                         {formatShortDate(show.show_date).split(',')[0]?.trim() ?? ''}
                       </span>
                       <span class="text-xs leading-tight font-bold">
-                        {new Date(show.show_date).getDate()}
+                        {getDayInTZ(show.show_date)}
                       </span>
                     </div>
                     <div class="min-w-0 flex-1">
@@ -324,7 +334,7 @@
   {#if isLoadingSeatMap}
     <div class="flex items-center justify-center py-20">
       <div class="flex flex-col items-center gap-3">
-        <Loader2 class="h-8 w-8 animate-spin text-primary" />
+        <LoaderCircle class="h-8 w-8 animate-spin text-primary" />
         <p class="text-sm text-muted-foreground">Đang tải sơ đồ ghế...</p>
       </div>
     </div>

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
@@ -91,6 +91,9 @@
       .toUpperCase();
   }
 
+  // Track active request to prevent stale responses
+  let activeAbortController: AbortController | null = null;
+
   async function switchShow(showId: number) {
     if (showId === currentShowId) {
       showPickerOpen = false;
@@ -100,10 +103,22 @@
     showPickerOpen = false;
     isLoadingSeatMap = true;
 
-    try {
-      const res = await api.get<SeatMapData>(`/events/${data.event.id}/shows/${showId}/seats`);
+    // Abort any previous request
+    if (activeAbortController) {
+      activeAbortController.abort();
+    }
 
-      if (res.data) {
+    // Create new AbortController for this request
+    const controller = new AbortController();
+    activeAbortController = controller;
+
+    try {
+      const res = await api.get<SeatMapData>(`/events/${data.event.id}/shows/${showId}/seats`, {
+        signal: controller.signal,
+      });
+
+      // Only update state if this request wasn't aborted (still the most recent)
+      if (!controller.signal.aborted && res.data) {
         currentShowId = showId;
         seatMap = res.data;
 
@@ -116,10 +131,18 @@
         const newUrl = `/events/${data.event.id}/shows/${showId}/seats`;
         history.replaceState(history.state, '', newUrl);
       }
-    } catch {
-      // Error already handled by api utility
+    } catch (error) {
+      // Ignore abort errors, they are expected when switching shows rapidly
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+      // Other errors already handled by api utility
     } finally {
-      isLoadingSeatMap = false;
+      // Only clear loading state if this is still the active request
+      if (activeAbortController === controller) {
+        isLoadingSeatMap = false;
+        activeAbortController = null;
+      }
     }
   }
 


### PR DESCRIPTION
## Mô tả

Cho phép cart hoạt động để mua nhiều vé từ nhiều show trong cùng một sự kiện

Closes #25 

## Loại thay đổi

- [x] ✨ Feature mới
- [x] 🐛 Bug fix
- [x] 💄 UI / Style

## Screenshots / Demo

<img width="3064" height="1812" alt="image" src="https://github.com/user-attachments/assets/557a934c-d21f-4c26-91b7-82894a630d3b" />


## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select and purchase tickets across multiple shows in a single checkout
  * Switch shows during seat selection with a show picker and seamless seat-map loading

* **Improvements**
  * Per‑show carts and summaries with per‑show clear/remove controls and multi‑show badges
  * Checkout now preserves per‑show seat and GA selections in query params
  * Updated logged-in dropdown trigger styling and show‑card visuals
  * Date/time display utilities refined for consistent short date formatting

* **Other**
  * Login redirects now trigger navigation-driven invalidation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->