### PR TITLE
feat(mq): implement order timeout and auto-release seat logic

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,9 +1,11 @@
 import { verifyAuthToken } from '$lib/server/auth/jwt';
+import { startWorker } from '$lib/server/mq/consumer';
 import { initMQWithRetry } from '$lib/server/mq/initMQ';
 import type { Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 
 const mqInitPromise = initMQWithRetry();
+await startWorker();
 
 await mqInitPromise;
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,9 +5,8 @@ import type { Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 
 const mqInitPromise = initMQWithRetry();
-await startWorker();
-
 await mqInitPromise;
+await startWorker();
 
 // ── Security headers (CSP + common hardening) ──
 const securityHeaders: Handle = async ({ event, resolve }) => {

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -101,6 +101,9 @@ export const Errors = {
     'Yêu cầu idempotency đang xung đột',
   ),
 
+  // MQ
+  MQ_UNAVAILABLE: new AppError('MQ_UNAVAILABLE', 503, 'Hệ thống tạm thời bận, vui lòng thử lại.'),
+
   // General
   NOT_FOUND: new AppError('NOT_FOUND', 404, 'Không tìm thấy'),
   INTERNAL_ERROR: new AppError('INTERNAL_ERROR', 500, 'Đã có lỗi xảy ra, vui lòng thử lại'),

--- a/src/lib/server/mq/connection.ts
+++ b/src/lib/server/mq/connection.ts
@@ -81,33 +81,3 @@ const shutdown = async (signal: string) => {
 
 process.once('SIGINT', () => shutdown('SIGINT'));
 process.once('SIGTERM', () => shutdown('SIGTERM'));
-
-// export async function publishTestMessage(queueName: string, message: object) {
-//   let connection;
-//   try {
-//     // 1. Kết nối tới CloudAMQP
-//     connection = await amqp.connect(AMQP_URL);
-//     const channel = await connection.createChannel();
-
-//     // 2. Khai báo hàng chờ (durable: true để message không mất khi restart)
-//     await channel.assertQueue(queueName, { durable: true });
-
-//     // 3. Gửi message (dưới dạng Buffer)
-//     const payload = JSON.stringify({
-//       ...message,
-//       timestamp: new Date().toISOString(),
-//     });
-
-//     channel.sendToQueue(queueName, Buffer.from(payload));
-
-//     console.log(`🚀 [MQ] Message sent to ${queueName}:`, payload);
-
-//     // 4. Đóng kết nối sau khi gửi (chỉ dùng cho mục đích test khởi tạo)
-//     await channel.close();
-//   } catch (error) {
-//     console.error('❌ [MQ] Publish failed:', error);
-//     throw error;
-//   } finally {
-//     if (connection) await connection.close();
-//   }
-// }

--- a/src/lib/server/mq/consumer.ts
+++ b/src/lib/server/mq/consumer.ts
@@ -37,17 +37,30 @@ export async function startWorker(retryCount = 0) {
         const retries = headers['x-retry'] ?? 0;
         const MAX_RETRIES = 3;
 
-        if (retries < MAX_RETRIES) {
-          console.warn(`[Worker] Retry ${retries + 1}/${MAX_RETRIES}`);
-          ch.sendToQueue('tixtac.order.release-process.retry', msg.content, {
-            headers: { ...headers, 'x-retry': retries + 1 },
-            persistent: true,
-          });
-        } else {
-          ch.sendToQueue('tixtac.order.release-process.dlq', msg.content, { persistent: true });
+        let republished = false;
+        try {
+          if (retries < MAX_RETRIES) {
+            console.warn(`[Worker] Retry ${retries + 1}/${MAX_RETRIES}`);
+            republished = ch.sendToQueue('tixtac.order.release-process.retry', msg.content, {
+              headers: { ...headers, 'x-retry': retries + 1 },
+              persistent: true,
+            });
+          } else {
+            republished = ch.sendToQueue('tixtac.order.release-process.dlq', msg.content, {
+              persistent: true,
+            });
+          }
+        } catch (publishErr) {
+          console.error('[Worker] Failed to republish to retry/DLQ:', publishErr);
+          // republished stays false
         }
 
-        ch.ack(msg);
+        if (republished) {
+          ch.ack(msg);
+        } else {
+          // nack with requeue so the message is retried by the broker
+          ch.nack(msg, false, true);
+        }
       }
     });
 

--- a/src/lib/server/mq/consumer.ts
+++ b/src/lib/server/mq/consumer.ts
@@ -1,0 +1,78 @@
+import { db } from '$lib/server/db';
+import { orderItems, orders, seats } from '$lib/server/db/schema';
+import { eq, inArray } from 'drizzle-orm';
+import { getChannel } from './connection';
+
+export async function startWorker() {
+  const ch = await getChannel();
+
+  ch.prefetch(10);
+
+  ch.consume('tixtac.order.release-process', async (msg) => {
+    if (!msg) return;
+
+    const { orderId } = JSON.parse(msg.content.toString());
+
+    let shouldAck = false;
+
+    try {
+      await db.transaction(async (tx) => {
+        const [order] = await tx.select().from(orders).where(eq(orders.id, orderId)).for('update');
+
+        if (!order) {
+          shouldAck = true;
+          return;
+        }
+
+        const now = new Date();
+
+        if (order.status !== 'pending' || order.expiresAt > now) {
+          console.log('[Worker] Skip order', orderId);
+          shouldAck = true;
+          return;
+        }
+
+        const items = await tx
+          .select({ seatId: orderItems.seatId })
+          .from(orderItems)
+          .where(eq(orderItems.orderId, orderId));
+
+        if (items.length === 0) {
+          shouldAck = true;
+          return;
+        }
+
+        await tx
+          .update(seats)
+          .set({
+            status: 'available',
+            lockedBy: null,
+            lockedAt: null,
+          })
+          .where(
+            inArray(
+              seats.id,
+              items.map((i) => i.seatId),
+            ),
+          );
+
+        await tx.update(orders).set({ status: 'cancelled' }).where(eq(orders.id, orderId));
+
+        console.log('[Worker] Released seats for order', orderId);
+
+        shouldAck = true;
+      });
+
+      if (shouldAck) ch.ack(msg);
+      else ch.nack(msg, false, true);
+    } catch (err) {
+      console.error('[Worker] Error:', err);
+      ch.ack(msg);
+    }
+  });
+
+  ch.on('close', () => {
+    console.warn('[Worker] Channel closed → restarting...');
+    setTimeout(startWorker, 1000);
+  });
+}

--- a/src/lib/server/mq/consumer.ts
+++ b/src/lib/server/mq/consumer.ts
@@ -1,6 +1,4 @@
-import { db } from '$lib/server/db';
-import { orderItems, orders, seats } from '$lib/server/db/schema';
-import { eq, inArray } from 'drizzle-orm';
+import { orderService } from '$lib/server/services/order.service';
 import { getChannel } from './connection';
 // import { EventBus } from '$lib/server/events';
 
@@ -13,108 +11,43 @@ export async function startWorker(retryCount = 0) {
     ch.consume('tixtac.order.release-process', async (msg) => {
       if (!msg) return;
 
+      let orderId: number;
       try {
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(msg.content.toString());
-        } catch {
-          console.error('[Worker] Invalid JSON → drop', msg.content.toString());
-          ch.ack(msg);
-          return;
-        }
-        if (typeof parsed !== 'object' || parsed === null || !('orderId' in parsed)) {
-          console.error('[Worker] Invalid payload → drop', parsed);
-          ch.ack(msg);
-          return;
-        }
-
-        const orderId = (parsed as { orderId: unknown }).orderId;
-
-        if (typeof orderId !== 'number') {
-          console.error('[Worker] orderId must be number → drop', parsed);
-          ch.ack(msg);
-          return;
-        }
-        let releasedSeatIds: number[] = [];
-        await db.transaction(async (tx) => {
-          const [order] = await tx
-            .select()
-            .from(orders)
-            .where(eq(orders.id, orderId))
-            .for('update');
-
-          if (!order) {
-            console.warn('[Worker] Order not found:', orderId);
-            return;
-          }
-
-          const now = new Date();
-
-          if (order.status !== 'pending') {
-            console.log('[Worker] Already processed:', orderId);
-            return;
-          }
-
-          if (order.expiresAt > now) {
-            console.log('[Worker] Not expired yet:', orderId);
-            return;
-          }
-
-          const items = await tx
-            .select({ seatId: orderItems.seatId })
-            .from(orderItems)
-            .where(eq(orderItems.orderId, orderId));
-
-          if (items.length === 0) {
-            console.warn('[Worker] No items found:', orderId);
-            return;
-          }
-          releasedSeatIds = items.map((i) => i.seatId);
-
-          await tx
-            .update(seats)
-            .set({
-              status: 'available',
-              lockedBy: null,
-              lockedAt: null,
-            })
-            .where(inArray(seats.id, releasedSeatIds));
-
-          await tx.update(orders).set({ status: 'cancelled' }).where(eq(orders.id, orderId));
-          console.log('[Worker] Released seats for order', orderId);
-        });
-
+        const parsed = JSON.parse(msg.content.toString());
+        if (typeof parsed?.orderId !== 'number') throw new Error('Invalid orderId');
+        orderId = parsed.orderId;
+      } catch {
+        console.error('[Worker] Invalid message → drop');
+        ch.ack(msg);
+        return;
+      }
+      try {
+        const { releasedSeatIds } = await orderService.releaseExpiredOrder(orderId);
         if (releasedSeatIds.length > 0) {
           // EventBus.emit('seats.released', {
           //   orderId,
           //   seatIds: releasedSeatIds,
           // });
         }
-
         ch.ack(msg);
       } catch (err) {
-        console.error('[Worker] Processing error:', err);
+        console.error(`[Worker] System error processing order ${orderId}:`, err);
 
         const headers = msg.properties.headers || {};
-        const retryCount = headers['x-retry'] ?? 0;
+        const retries = headers['x-retry'] ?? 0;
         const MAX_RETRIES = 3;
 
-        if (retryCount < MAX_RETRIES) {
-          console.warn(`[Worker] Retry ${retryCount + 1}/${MAX_RETRIES}`);
-
+        if (retries < MAX_RETRIES) {
+          console.warn(`[Worker] Retry ${retries + 1}/${MAX_RETRIES}`);
           ch.sendToQueue('tixtac.order.release-process.retry', msg.content, {
-            headers: {
-              ...headers,
-              'x-retry': retryCount + 1,
-            },
+            headers: { ...headers, 'x-retry': retries + 1 },
             persistent: true,
           });
-
-          ch.ack(msg);
         } else {
           ch.sendToQueue('tixtac.order.release-process.dlq', msg.content, { persistent: true });
-          ch.ack(msg);
         }
+
+        ch.ack(msg);
       }
     });
 
@@ -128,9 +61,7 @@ export async function startWorker(retryCount = 0) {
     });
   } catch (err) {
     console.error('[Worker] Startup error:', err);
-
     const delay = Math.min(1000 * 2 ** retryCount, 30000);
-
     setTimeout(() => {
       startWorker(retryCount + 1);
     }, delay);

--- a/src/lib/server/mq/consumer.ts
+++ b/src/lib/server/mq/consumer.ts
@@ -2,77 +2,137 @@ import { db } from '$lib/server/db';
 import { orderItems, orders, seats } from '$lib/server/db/schema';
 import { eq, inArray } from 'drizzle-orm';
 import { getChannel } from './connection';
+// import { EventBus } from '$lib/server/events';
 
-export async function startWorker() {
-  const ch = await getChannel();
+export async function startWorker(retryCount = 0) {
+  try {
+    const ch = await getChannel();
 
-  ch.prefetch(10);
+    await ch.prefetch(10);
 
-  ch.consume('tixtac.order.release-process', async (msg) => {
-    if (!msg) return;
+    ch.consume('tixtac.order.release-process', async (msg) => {
+      if (!msg) return;
 
-    const { orderId } = JSON.parse(msg.content.toString());
-
-    let shouldAck = false;
-
-    try {
-      await db.transaction(async (tx) => {
-        const [order] = await tx.select().from(orders).where(eq(orders.id, orderId)).for('update');
-
-        if (!order) {
-          shouldAck = true;
+      try {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(msg.content.toString());
+        } catch {
+          console.error('[Worker] Invalid JSON → drop', msg.content.toString());
+          ch.ack(msg);
+          return;
+        }
+        if (typeof parsed !== 'object' || parsed === null || !('orderId' in parsed)) {
+          console.error('[Worker] Invalid payload → drop', parsed);
+          ch.ack(msg);
           return;
         }
 
-        const now = new Date();
+        const orderId = (parsed as { orderId: unknown }).orderId;
 
-        if (order.status !== 'pending' || order.expiresAt > now) {
-          console.log('[Worker] Skip order', orderId);
-          shouldAck = true;
+        if (typeof orderId !== 'number') {
+          console.error('[Worker] orderId must be number → drop', parsed);
+          ch.ack(msg);
           return;
         }
+        let releasedSeatIds: number[] = [];
+        await db.transaction(async (tx) => {
+          const [order] = await tx
+            .select()
+            .from(orders)
+            .where(eq(orders.id, orderId))
+            .for('update');
 
-        const items = await tx
-          .select({ seatId: orderItems.seatId })
-          .from(orderItems)
-          .where(eq(orderItems.orderId, orderId));
+          if (!order) {
+            console.warn('[Worker] Order not found:', orderId);
+            return;
+          }
 
-        if (items.length === 0) {
-          shouldAck = true;
-          return;
+          const now = new Date();
+
+          if (order.status !== 'pending') {
+            console.log('[Worker] Already processed:', orderId);
+            return;
+          }
+
+          if (order.expiresAt > now) {
+            console.log('[Worker] Not expired yet:', orderId);
+            return;
+          }
+
+          const items = await tx
+            .select({ seatId: orderItems.seatId })
+            .from(orderItems)
+            .where(eq(orderItems.orderId, orderId));
+
+          if (items.length === 0) {
+            console.warn('[Worker] No items found:', orderId);
+            return;
+          }
+          releasedSeatIds = items.map((i) => i.seatId);
+
+          await tx
+            .update(seats)
+            .set({
+              status: 'available',
+              lockedBy: null,
+              lockedAt: null,
+            })
+            .where(inArray(seats.id, releasedSeatIds));
+
+          await tx.update(orders).set({ status: 'cancelled' }).where(eq(orders.id, orderId));
+          console.log('[Worker] Released seats for order', orderId);
+        });
+
+        if (releasedSeatIds.length > 0) {
+          // EventBus.emit('seats.released', {
+          //   orderId,
+          //   seatIds: releasedSeatIds,
+          // });
         }
 
-        await tx
-          .update(seats)
-          .set({
-            status: 'available',
-            lockedBy: null,
-            lockedAt: null,
-          })
-          .where(
-            inArray(
-              seats.id,
-              items.map((i) => i.seatId),
-            ),
-          );
+        ch.ack(msg);
+      } catch (err) {
+        console.error('[Worker] Processing error:', err);
 
-        await tx.update(orders).set({ status: 'cancelled' }).where(eq(orders.id, orderId));
+        const headers = msg.properties.headers || {};
+        const retryCount = headers['x-retry'] ?? 0;
+        const MAX_RETRIES = 3;
 
-        console.log('[Worker] Released seats for order', orderId);
+        if (retryCount < MAX_RETRIES) {
+          console.warn(`[Worker] Retry ${retryCount + 1}/${MAX_RETRIES}`);
 
-        shouldAck = true;
-      });
+          ch.sendToQueue('tixtac.order.release-process.retry', msg.content, {
+            headers: {
+              ...headers,
+              'x-retry': retryCount + 1,
+            },
+            persistent: true,
+          });
 
-      if (shouldAck) ch.ack(msg);
-      else ch.nack(msg, false, true);
-    } catch (err) {
-      console.error('[Worker] Error:', err);
-      ch.ack(msg);
-    }
-  });
+          ch.ack(msg);
+        } else {
+          ch.sendToQueue('tixtac.order.release-process.dlq', msg.content, { persistent: true });
+          ch.ack(msg);
+        }
+      }
+    });
 
-  ch.on('close', () => {
-    console.warn('[Worker] Channel closed → restarting...');
-    setTimeout(startWorker, 1000);
-  });
+    ch.once('close', () => {
+      const nextRetry = retryCount + 1;
+      const delay = Math.min(1000 * 2 ** nextRetry, 30000); // max 30s
+      console.warn(`[Worker] Channel closed → retry in ${delay}ms`);
+      setTimeout(() => {
+        startWorker(nextRetry);
+      }, delay);
+    });
+  } catch (err) {
+    console.error('[Worker] Startup error:', err);
+
+    const delay = Math.min(1000 * 2 ** retryCount, 30000);
+
+    setTimeout(() => {
+      startWorker(retryCount + 1);
+    }, delay);
+  }
 }

--- a/src/lib/server/mq/initMQ.ts
+++ b/src/lib/server/mq/initMQ.ts
@@ -23,6 +23,19 @@ export async function initMQ() {
     durable: true,
   });
 
+  await ch.assertQueue('tixtac.order.release-process.retry', {
+    durable: true,
+    arguments: {
+      'x-dead-letter-exchange': '',
+      'x-dead-letter-routing-key': 'tixtac.order.release-process',
+      'x-message-ttl': 10000, // delay 10s
+    },
+  });
+
+  await ch.assertQueue('tixtac.order.release-process.dlq', {
+    durable: true,
+  });
+
   // Bindings
   await ch.bindQueue('tixtac.order.delay', 'tixtac.main', 'order-hold');
   await ch.bindQueue('tixtac.order.release-process', 'tixtac.release-dlx', 'release-task');

--- a/src/lib/server/mq/publisher.ts
+++ b/src/lib/server/mq/publisher.ts
@@ -1,11 +1,5 @@
 import { config } from '$lib/server/config';
-import type { CheckoutBody } from '$lib/shared/schemas';
 import { getChannel } from './connection';
-
-export type OrderHoldMessage = {
-  payload: CheckoutBody;
-  ttl?: number;
-};
 
 export async function publishOrderTimeout(orderId: number, ttl?: number) {
   const ch = await getChannel();

--- a/src/lib/server/mq/publisher.ts
+++ b/src/lib/server/mq/publisher.ts
@@ -1,4 +1,3 @@
-import { config } from '$lib/server/config';
 import type { CheckoutBody } from '$lib/shared/schemas';
 import { getChannel } from './connection';
 
@@ -7,27 +6,14 @@ export type OrderHoldMessage = {
   ttl?: number;
 };
 
-export async function publishOrderHold(payload: OrderHoldMessage) {
-  const ch = await getChannel();
-
-  const success = ch.publish('tixtac.main', 'order-hold', Buffer.from(JSON.stringify(payload)), {
-    persistent: true,
-    expiration: String(payload.ttl ?? config.seatLockDuration * 1000), // override nếu cần
-  });
-
-  if (!success) {
-    console.warn('[MQ] Publish buffer full');
-  }
-}
-
-export async function publishOrderTimeout(orderId: number) {
+export async function publishOrderTimeout(orderId: number, ttl?: number) {
   const ch = await getChannel();
 
   const payload = JSON.stringify({ orderId });
 
   const ok = ch.publish('tixtac.main', 'order-hold', Buffer.from(payload), {
     persistent: true,
-    expiration: String(config.seatLockDuration * 1000),
+    expiration: ttl ? String(ttl) : undefined, // optional
   });
 
   if (!ok) {

--- a/src/lib/server/mq/publisher.ts
+++ b/src/lib/server/mq/publisher.ts
@@ -19,3 +19,18 @@ export async function publishOrderHold(payload: OrderHoldMessage) {
     console.warn('[MQ] Publish buffer full');
   }
 }
+
+export async function publishOrderTimeout(orderId: number) {
+  const ch = await getChannel();
+
+  const payload = JSON.stringify({ orderId });
+
+  const ok = ch.publish('tixtac.main', 'order-hold', Buffer.from(payload), {
+    persistent: true,
+    expiration: String(config.seatLockDuration * 1000),
+  });
+
+  if (!ok) {
+    console.warn('[MQ] Publish buffer full');
+  }
+}

--- a/src/lib/server/mq/publisher.ts
+++ b/src/lib/server/mq/publisher.ts
@@ -1,3 +1,4 @@
+import { config } from '$lib/server/config';
 import type { CheckoutBody } from '$lib/shared/schemas';
 import { getChannel } from './connection';
 
@@ -11,9 +12,11 @@ export async function publishOrderTimeout(orderId: number, ttl?: number) {
 
   const payload = JSON.stringify({ orderId });
 
+  const expiration = ttl ?? config.seatLockDuration * 1000;
+
   const ok = ch.publish('tixtac.main', 'order-hold', Buffer.from(payload), {
     persistent: true,
-    expiration: ttl ? String(ttl) : undefined, // optional
+    expiration: String(expiration), // optional
   });
 
   if (!ok) {

--- a/src/lib/server/services/order.service.ts
+++ b/src/lib/server/services/order.service.ts
@@ -435,16 +435,23 @@ export const orderService = {
 
       const seatIds = items.map((i) => i.seatId);
 
-      // Giải phóng ghế về trạng thái available
-      await tx
+      // Chỉ release ghế đang thật sự locked bởi chính user của đơn này.
+      const released = await tx
         .update(seats)
         .set({ status: 'available', lockedBy: null, lockedAt: null })
-        .where(inArray(seats.id, seatIds));
+        .where(
+          and(
+            inArray(seats.id, seatIds),
+            eq(seats.status, 'locked'),
+            eq(seats.lockedBy, order.userId),
+          ),
+        )
+        .returning({ id: seats.id });
 
       // Hủy đơn hàng
       await tx.update(orders).set({ status: 'cancelled' }).where(eq(orders.id, orderId));
 
-      return { releasedSeatIds: seatIds };
+      return { releasedSeatIds: released.map((r) => r.id) };
     });
   },
 };

--- a/src/lib/server/services/order.service.ts
+++ b/src/lib/server/services/order.service.ts
@@ -401,4 +401,50 @@ export const orderService = {
       paid_events: Array.from(paidEventsMap.values()),
     };
   },
+
+  async releaseExpiredOrder(orderId: number): Promise<{ releasedSeatIds: number[] }> {
+    return db.transaction(async (tx) => {
+      const [order] = await tx.select().from(orders).where(eq(orders.id, orderId)).for('update');
+
+      if (!order) {
+        // Không có đơn hàng → coi như không có gì để giải phóng
+        return { releasedSeatIds: [] };
+      }
+
+      if (order.status !== 'pending') {
+        // Đã xử lý rồi (paid/cancelled/…) → không làm gì
+        return { releasedSeatIds: [] };
+      }
+
+      const now = new Date();
+      if (order.expiresAt > now) {
+        // Chưa hết hạn → giữ nguyên
+        return { releasedSeatIds: [] };
+      }
+
+      const items = await tx
+        .select({ seatId: orderItems.seatId })
+        .from(orderItems)
+        .where(eq(orderItems.orderId, orderId));
+
+      if (items.length === 0) {
+        // Không có items vẫn cần hủy order để đồng bộ trạng thái
+        await tx.update(orders).set({ status: 'cancelled' }).where(eq(orders.id, orderId));
+        return { releasedSeatIds: [] };
+      }
+
+      const seatIds = items.map((i) => i.seatId);
+
+      // Giải phóng ghế về trạng thái available
+      await tx
+        .update(seats)
+        .set({ status: 'available', lockedBy: null, lockedAt: null })
+        .where(inArray(seats.id, seatIds));
+
+      // Hủy đơn hàng
+      await tx.update(orders).set({ status: 'cancelled' }).where(eq(orders.id, orderId));
+
+      return { releasedSeatIds: seatIds };
+    });
+  },
 };

--- a/src/lib/server/services/purchase.service.ts
+++ b/src/lib/server/services/purchase.service.ts
@@ -10,6 +10,7 @@ import {
   users,
 } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
+import { config } from '$lib/server/config';
 import { publishOrderTimeout } from '$lib/server/mq/publisher';
 import type { DbTransaction } from '$lib/types/db';
 import type { PurchaseBody, PurchaseResponse } from '$lib/types/purchase';
@@ -336,7 +337,7 @@ export const purchaseService = {
         }
 
         // 3. Cập nhật State
-        const expiresAt = new Date(now.getTime() + 10 * 60 * 1000);
+        const expiresAt = new Date(now.getTime() + config.seatLockDuration * 1000);
 
         await tx
           .update(seats)

--- a/src/lib/server/services/purchase.service.ts
+++ b/src/lib/server/services/purchase.service.ts
@@ -402,9 +402,9 @@ export const purchaseService = {
         };
       });
 
-      if (responseData.isNewOrder) {
-        await publishOrderTimeout(responseData.order_id);
-      }
+      // Always (re)publish a timeout message: the consumer's `expiresAt > now`
+      // check will drop any earlier stale message after the deadline is extended.
+      await publishOrderTimeout(responseData.order_id);
 
       return responseData;
     } catch (error) {

--- a/src/lib/server/services/purchase.service.ts
+++ b/src/lib/server/services/purchase.service.ts
@@ -1,3 +1,4 @@
+import { config } from '$lib/server/config';
 import { db } from '$lib/server/db';
 import {
   events,
@@ -10,8 +11,8 @@ import {
   users,
 } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
-import { config } from '$lib/server/config';
 import { publishOrderTimeout } from '$lib/server/mq/publisher';
+import { orderService } from '$lib/server/services/order.service';
 import type { DbTransaction } from '$lib/types/db';
 import type { PurchaseBody, PurchaseResponse } from '$lib/types/purchase';
 import { generateTicketCode } from '$lib/utils/ticket-code';
@@ -405,7 +406,14 @@ export const purchaseService = {
 
       // Always (re)publish a timeout message: the consumer's `expiresAt > now`
       // check will drop any earlier stale message after the deadline is extended.
-      await publishOrderTimeout(responseData.order_id);
+      try {
+        await publishOrderTimeout(responseData.order_id);
+      } catch (mqErr) {
+        console.error('[purchase] publishOrderTimeout failed; rolling back order', mqErr);
+        // Compensate: release seats and cancel the order so client can retry.
+        await orderService.releaseExpiredOrder(responseData.order_id).catch(() => {});
+        throwError(Errors.MQ_UNAVAILABLE, 'Hệ thống tạm thời bận, vui lòng thử lại.');
+      }
 
       return responseData;
     } catch (error) {

--- a/src/lib/server/services/purchase.service.ts
+++ b/src/lib/server/services/purchase.service.ts
@@ -10,6 +10,7 @@ import {
   users,
 } from '$lib/server/db/schema';
 import { Errors, throwError } from '$lib/server/errors';
+import { publishOrderTimeout } from '$lib/server/mq/publisher';
 import type { DbTransaction } from '$lib/types/db';
 import type { PurchaseBody, PurchaseResponse } from '$lib/types/purchase';
 import { generateTicketCode } from '$lib/utils/ticket-code';
@@ -395,8 +396,15 @@ export const purchaseService = {
             .where(eq(idempotencyKeys.key, idempotencyKey));
         }
 
-        return finalResponse;
+        return {
+          ...finalResponse,
+          isNewOrder: !pendingOrderId,
+        };
       });
+
+      if (responseData.isNewOrder) {
+        await publishOrderTimeout(responseData.order_id);
+      }
 
       return responseData;
     } catch (error) {


### PR DESCRIPTION
## Mô tả
Triển khai hệ thống tự động hủy đơn hàng và nhả ghế sử dụng RabbitMQ. Đảm bảo ghế được giải phóng nếu khách hàng không hoàn tất thanh toán sau 10 phút.

Closes #87  

## Loại thay đổi

- [x] ✨ Feature mới

## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)

## Ghi chú cho reviewer
- Test db đang bị lỗi nếu cancelled order thì seat sẽ bị out khỏi seat_section (có thể do join??)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expired pending orders are automatically cancelled and locked seats released.
  * Background worker processes order-release messages, with validation, retries, retry-queue, dead-letter handling and auto-restart; worker now starts on server startup.
  * Purchase flow always schedules order-timeout notifications using configured seat-lock duration.
  * Order-timeout messages simplified to include only the order identifier (and optional TTL).

* **Chores**
  * Removed obsolete commented test helper; added queues to support retry/DLQ flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->