### PR TITLE
feat(ui): implement virtual queue frontend flow and floating widget

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -86,10 +86,13 @@ async function runQueueWorker(): Promise<WorkerResult> {
     console.log(`[QueueWorker] Found eventIds:`, eventIdsArray);
 
     const now = Date.now();
-    const slotDurationMs = config.accessTokenDuration * 1000;
+    // Workers promote from the waiting list with only the grace period (60s) so
+    // users must explicitly confirm before receiving the full holding duration.
+    const gracePeriodSeconds = 60;
+    const slotDurationMs = gracePeriodSeconds * 1000;
     const maxUsers = config.maxConcurrentUsers ?? 200;
     const waitingTtlMs = 3600 * 1000;
-    const activeTtl = config.accessTokenDuration + 5;
+    const activeTtl = gracePeriodSeconds + 5;
 
     let didWork = false;
     let hasWaitingUsers = false;
@@ -98,8 +101,8 @@ async function runQueueWorker(): Promise<WorkerResult> {
       const activeKey = `active_users:${eventId}`;
       const waitingKey = `waiting_queue:${eventId}`;
 
-      // A1. Evict expired active users — safe delete: only remove user_current_queue
-      //     if it still points to this event.
+      // Step A1: Evict expired active users — conditionally removes `user_current_queue`
+      //          only if it still points to this event (safe delete).
       const expiredUserIds = await redis.zrange(activeKey, 0, now, { byScore: true });
 
       if (expiredUserIds.length > 0) {
@@ -114,11 +117,13 @@ async function runQueueWorker(): Promise<WorkerResult> {
         }
         pipeline.zremrangebyscore(activeKey, 0, now);
         await pipeline.exec();
-        console.log(`[QueueWorker] 🧹 Đuổi ${expiredUserIds.length} users khỏi Event ${eventId}`);
+        console.log(
+          `[QueueWorker] 🧹 Evicted ${expiredUserIds.length} expired users from Event ${eventId}`,
+        );
       }
 
-      // A2. Evict stale waiting users whose user_current_queue TTL (1h) has expired.
-      //     Ensures users don't linger in waiting_queue after their tracking key is gone.
+      // Step A2: Evict stale waiting users whose 1-hour tracking TTL has elapsed.
+      //          Prevents ghost entries in the waiting sorted set.
       const staleBefore = now - waitingTtlMs;
       const staleWaitingUserIds = await redis.zrange(waitingKey, 0, staleBefore, {
         byScore: true,
@@ -141,8 +146,8 @@ async function runQueueWorker(): Promise<WorkerResult> {
         );
       }
 
-      // B. Promote waiting users into available slots — safe: only promote if
-      //     user_current_queue still maps to this event.
+      // Step B: Promote waiting users into available slots — atomically checks
+      //         `user_current_queue` to ensure the user hasn’t left in the meantime.
       const currentActiveCount = await redis.zcount(activeKey, now, '+inf');
       const availableSlots = Math.max(0, maxUsers - currentActiveCount);
 
@@ -168,7 +173,7 @@ async function runQueueWorker(): Promise<WorkerResult> {
         }
       }
 
-      // C. Recompute after eviction + promotion before deciding GC
+      // Step C: Recompute counts after eviction and promotion to decide on GC.
       const [activeCountAfterRaw, waitingCountAfterRaw] = await redis
         .pipeline()
         .zcount(activeKey, now, '+inf')

--- a/src/lib/components/customer/layout/CustomerNavbar.svelte
+++ b/src/lib/components/customer/layout/CustomerNavbar.svelte
@@ -1,7 +1,6 @@
 <!-- src/lib/components/customer/layout/CustomerNavbar.svelte -->
 <script lang="ts">
-  import { enhance } from '$app/forms';
-  import { goto, invalidateAll } from '$app/navigation';
+  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page as pageState } from '$app/state';
   import Logo2 from '$lib/assets/Logo2.svelte';
@@ -21,6 +20,7 @@
   import { CircleUserRound, House, LogOut, Search, Ticket, User } from 'lucide-svelte';
   import { toggleMode } from 'mode-watcher';
   import { onMount, tick } from 'svelte';
+  import { queueStore } from '$lib/stores/queue.svelte';
 
   interface Props {
     user?: UserInfo;
@@ -68,11 +68,30 @@
     isSearchOpen = !isSearchOpen;
   }
 
-  function handleLogout() {
-    return async () => {
-      await invalidateAll();
-      await goto(resolve('/'));
-    };
+  /**
+   * Handles the logout flow:
+   * 1. Calls the server-side logout API (which releases any Redis queue slot).
+   * 2. Clears the client-side queue store (removes localStorage data + hides widget).
+   * 3. Forces a full page reload to `/` to ensure all reactive state is reset.
+   */
+  async function handleLogout(event: Event) {
+    event.preventDefault();
+
+    try {
+      const res = await fetch(resolve('/api/auth/logout'), { method: 'POST' });
+
+      if (res.ok) {
+        // Clear the client-side queue widget state.
+        queueStore.clear();
+
+        // Hard redirect — ensures all SvelteKit stores and server data are fully reset.
+        window.location.href = resolve('/');
+      } else {
+        console.error('Logout failed');
+      }
+    } catch (err) {
+      console.error('Logout error:', err);
+    }
   }
 
   let currentPath = $derived(pageState.url.pathname);
@@ -242,7 +261,7 @@
                   <span>Vé của tôi</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <form action={resolve('/api/auth/logout')} method="POST" use:enhance={handleLogout}>
+                <form onsubmit={handleLogout}>
                   <DropdownMenuItem variant="destructive" class="cursor-pointer">
                     <button
                       type="submit"

--- a/src/lib/components/customer/layout/CustomerNavbar.svelte
+++ b/src/lib/components/customer/layout/CustomerNavbar.svelte
@@ -80,17 +80,15 @@
     try {
       const res = await fetch(resolve('/api/auth/logout'), { method: 'POST' });
 
-      if (res.ok) {
-        // Clear the client-side queue widget state.
-        queueStore.clear();
-
-        // Hard redirect — ensures all SvelteKit stores and server data are fully reset.
-        window.location.href = resolve('/');
-      } else {
-        console.error('Logout failed');
+      if (!res.ok) {
+        console.warn('Logout thất bại, nhưng đã xóa local state!');
       }
     } catch (err) {
-      console.error('Logout error:', err);
+      console.error(err);
+      console.warn('Lỗi mạng trong quá trình Logout, xóa local state!');
+    } finally {
+      queueStore.clear();
+      window.location.href = resolve('/');
     }
   }
 

--- a/src/lib/components/customer/queue/CrossQueueModal.svelte
+++ b/src/lib/components/customer/queue/CrossQueueModal.svelte
@@ -1,0 +1,100 @@
+<!-- src/lib/components/customer/queue/CrossQueueModal.svelte -->
+<script lang="ts">
+  import { AlertTriangle, ArrowRight, X } from 'lucide-svelte';
+
+  interface Props {
+    open: boolean;
+    currentEventTitle: string;
+    newEventTitle: string;
+    onStay: () => void;
+    onLeaveAndJoin: () => void;
+  }
+
+  let { open, currentEventTitle, newEventTitle, onStay, onLeaveAndJoin }: Props = $props();
+</script>
+
+{#if open}
+  <!-- Backdrop -->
+  <div
+    class="fixed inset-0 z-[60] flex items-center justify-center p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="cross-queue-title"
+  >
+    <!-- Overlay -->
+    <button
+      class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+      onclick={onStay}
+      aria-label="Đóng"
+    ></button>
+
+    <!-- Modal Card -->
+    <div
+      class="relative z-10 w-full max-w-md animate-in overflow-hidden rounded-2xl bg-surface shadow-2xl duration-200 zoom-in-95 slide-in-from-bottom-4"
+    >
+      <!-- Header -->
+      <div class="flex items-start gap-4 bg-amber-500/10 p-6 pb-5">
+        <div
+          class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-amber-500/20 text-amber-600"
+        >
+          <AlertTriangle class="h-6 w-6" />
+        </div>
+        <div class="flex-1 pr-6">
+          <h2 id="cross-queue-title" class="font-heading text-lg font-bold text-foreground">
+            Đang xếp hàng sự kiện khác
+          </h2>
+          <p class="mt-1 text-sm text-muted-foreground">
+            Bạn chỉ có thể xếp hàng một sự kiện tại một thời điểm.
+          </p>
+        </div>
+        <button
+          onclick={onStay}
+          class="absolute top-4 right-4 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-surface-container-high hover:text-foreground"
+          aria-label="Đóng"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="space-y-3 p-6">
+        <!-- Current queue -->
+        <div class="rounded-xl border border-outline-variant/40 bg-surface-container-low p-4">
+          <p class="mb-1 text-[10px] font-bold tracking-widest text-muted-foreground uppercase">
+            Đang xếp hàng
+          </p>
+          <p class="line-clamp-2 font-semibold text-foreground">{currentEventTitle}</p>
+        </div>
+
+        <!-- Arrow -->
+        <div class="flex justify-center text-muted-foreground">
+          <ArrowRight class="h-5 w-5 rotate-90" />
+        </div>
+
+        <!-- New queue -->
+        <div class="rounded-xl border border-primary/30 bg-primary-container/10 p-4">
+          <p class="mb-1 text-[10px] font-bold tracking-widest text-primary uppercase">
+            Muốn tham gia
+          </p>
+          <p class="line-clamp-2 font-semibold text-foreground">{newEventTitle}</p>
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex flex-col gap-3 px-6 pb-6">
+        <button
+          onclick={onLeaveAndJoin}
+          class="w-full rounded-xl bg-gradient-to-br from-primary to-primary/80 px-6 py-3.5 font-bold text-primary-foreground shadow-lg shadow-primary/25 transition-all hover:opacity-90 active:scale-95"
+        >
+          Rời cũ & Tham gia mới
+        </button>
+        <button
+          onclick={onStay}
+          class="w-full rounded-xl bg-surface-container-highest px-6 py-3 text-sm font-semibold text-foreground transition hover:bg-surface-container-high active:scale-95"
+        >
+          Ở lại hàng chờ hiện tại
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/customer/queue/CrossQueueModal.svelte
+++ b/src/lib/components/customer/queue/CrossQueueModal.svelte
@@ -1,6 +1,6 @@
-<!-- src/lib/components/customer/queue/CrossQueueModal.svelte -->
 <script lang="ts">
   import { AlertTriangle, ArrowRight, X } from 'lucide-svelte';
+  import { tick } from 'svelte';
 
   interface Props {
     open: boolean;
@@ -11,28 +11,50 @@
   }
 
   let { open, currentEventTitle, newEventTitle, onStay, onLeaveAndJoin }: Props = $props();
+
+  let dialogRef: HTMLDivElement | undefined = $state();
+  let previousFocus: HTMLElement | null = null;
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (open && event.key === 'Escape') {
+      onStay();
+    }
+  }
+
+  $effect(() => {
+    if (open) {
+      previousFocus = document.activeElement as HTMLElement;
+
+      tick().then(() => {
+        if (dialogRef) dialogRef.focus();
+      });
+    } else if (previousFocus) {
+      previousFocus.focus();
+      previousFocus = null;
+    }
+  });
 </script>
 
+<svelte:window onkeydown={handleKeydown} />
+
 {#if open}
-  <!-- Backdrop -->
   <div
-    class="fixed inset-0 z-[60] flex items-center justify-center p-4"
+    bind:this={dialogRef}
+    tabindex="-1"
+    class="fixed inset-0 z-[60] flex items-center justify-center p-4 outline-none"
     role="dialog"
     aria-modal="true"
     aria-labelledby="cross-queue-title"
   >
-    <!-- Overlay -->
     <button
       class="absolute inset-0 bg-black/60 backdrop-blur-sm"
       onclick={onStay}
       aria-label="Đóng"
     ></button>
 
-    <!-- Modal Card -->
     <div
       class="relative z-10 w-full max-w-md animate-in overflow-hidden rounded-2xl bg-surface shadow-2xl duration-200 zoom-in-95 slide-in-from-bottom-4"
     >
-      <!-- Header -->
       <div class="flex items-start gap-4 bg-amber-500/10 p-6 pb-5">
         <div
           class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-amber-500/20 text-amber-600"
@@ -56,9 +78,7 @@
         </button>
       </div>
 
-      <!-- Body -->
       <div class="space-y-3 p-6">
-        <!-- Current queue -->
         <div class="rounded-xl border border-outline-variant/40 bg-surface-container-low p-4">
           <p class="mb-1 text-[10px] font-bold tracking-widest text-muted-foreground uppercase">
             Đang xếp hàng
@@ -66,12 +86,10 @@
           <p class="line-clamp-2 font-semibold text-foreground">{currentEventTitle}</p>
         </div>
 
-        <!-- Arrow -->
         <div class="flex justify-center text-muted-foreground">
           <ArrowRight class="h-5 w-5 rotate-90" />
         </div>
 
-        <!-- New queue -->
         <div class="rounded-xl border border-primary/30 bg-primary-container/10 p-4">
           <p class="mb-1 text-[10px] font-bold tracking-widest text-primary uppercase">
             Muốn tham gia
@@ -80,7 +98,6 @@
         </div>
       </div>
 
-      <!-- Actions -->
       <div class="flex flex-col gap-3 px-6 pb-6">
         <button
           onclick={onLeaveAndJoin}

--- a/src/lib/components/customer/queue/QueueHolding.svelte
+++ b/src/lib/components/customer/queue/QueueHolding.svelte
@@ -1,28 +1,60 @@
 <script lang="ts">
-  import { ArrowLeft, LogOut, Timer } from 'lucide-svelte';
+  import { Timer, ArrowLeft, LogOut } from 'lucide-svelte';
   import { queueStore } from '$lib/stores/queue.svelte';
 
-  interface Props {
+  type Props = {
     formattedTime: string;
     onGoToSeats: () => void;
     onExitClick: () => void;
-  }
+  };
   let { formattedTime, onGoToSeats, onExitClick }: Props = $props();
 </script>
 
-<div class="bg-orange-500 p-4 text-white">
-  <!-- Decoration -->
-  <div class="absolute -top-6 -left-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+<div class="bg-orange-500 p-1.5 sm:p-4 text-white">
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- MOBILE PILL VIEW (< 640px)                  -->
+  <!-- ═══════════════════════════════════════════ -->
+  <div class="flex items-center gap-2 sm:hidden pl-1 pr-0.5">
+    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/20">
+      <Timer class="h-4 w-4" />
+    </div>
+    
+    <span class="font-mono text-lg font-black">{formattedTime}</span>
+    
+    <div class="mx-1 h-5 w-px bg-white/20"></div>
+    
+    <button
+      onclick={onGoToSeats}
+      class="flex h-8 w-8 items-center justify-center rounded-full bg-white/20 text-white transition active:scale-95"
+      title="Quay lại chọn ghế"
+    >
+      <ArrowLeft class="h-4 w-4 -rotate-180" />
+    </button>
 
-  <div class="relative">
+    <button
+      onclick={onExitClick}
+      class="flex h-8 w-8 items-center justify-center rounded-full bg-black/20 text-white transition active:scale-95"
+      title="Thoát phiên"
+    >
+      <LogOut class="h-4 w-4" />
+    </button>
+  </div>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- DESKTOP CARD VIEW (>= 640px)                -->
+  <!-- ═══════════════════════════════════════════ -->
+  <div class="hidden sm:block relative">
+    <!-- Decoration -->
+    <div class="absolute -top-10 -left-10 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+    
     <div class="mb-3 flex items-center gap-3">
       <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
         <Timer class="h-5 w-5" />
       </div>
-      <div>
+      <div class="min-w-0 flex-1">
         <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">Phiên chọn ghế</p>
         {#if queueStore.eventTitle}
-          <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
+          <p class="truncate text-xs font-semibold">{queueStore.eventTitle}</p>
         {/if}
       </div>
     </div>

--- a/src/lib/components/customer/queue/QueueHolding.svelte
+++ b/src/lib/components/customer/queue/QueueHolding.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { ArrowLeft, LogOut, Timer } from 'lucide-svelte';
+  import { queueStore } from '$lib/stores/queue.svelte';
+
+  interface Props {
+    formattedTime: string;
+    onGoToSeats: () => void;
+    onExitClick: () => void;
+  }
+  let { formattedTime, onGoToSeats, onExitClick }: Props = $props();
+</script>
+
+<div class="bg-orange-500 p-4 text-white">
+  <!-- Decoration -->
+  <div class="absolute -top-6 -left-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+
+  <div class="relative">
+    <div class="mb-3 flex items-center gap-3">
+      <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
+        <Timer class="h-5 w-5" />
+      </div>
+      <div>
+        <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">Phiên chọn ghế</p>
+        {#if queueStore.eventTitle}
+          <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Countdown -->
+    <div class="mb-3 flex items-center justify-between rounded-xl bg-black/20 px-4 py-2.5">
+      <span class="text-xs opacity-80">Hết hạn sau:</span>
+      <span class="font-mono text-2xl font-black tabular-nums">{formattedTime}</span>
+    </div>
+
+    <!-- Actions -->
+    <div class="flex gap-2">
+      <button
+        onclick={onGoToSeats}
+        class="flex-1 rounded-xl bg-white py-2.5 text-xs font-bold text-orange-600 transition-all hover:bg-white/90 active:scale-95"
+      >
+        <ArrowLeft class="mr-1 inline-block h-3.5 w-3.5 -rotate-180" />
+        Quay lại chọn ghế
+      </button>
+      <button
+        onclick={onExitClick}
+        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-black/20 text-white transition hover:bg-black/30"
+        title="Thoát phiên chọn ghế"
+      >
+        <LogOut class="h-4 w-4" />
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/lib/components/customer/queue/QueueHolding.svelte
+++ b/src/lib/components/customer/queue/QueueHolding.svelte
@@ -10,33 +10,33 @@
   let { formattedTime, onGoToSeats, onExitClick }: Props = $props();
 </script>
 
-<div class="bg-orange-500 p-1.5 sm:p-4 text-white">
+<div class="bg-orange-500 p-2 sm:p-4 text-white shadow-inner sm:shadow-none">
   <!-- ═══════════════════════════════════════════ -->
   <!-- MOBILE PILL VIEW (< 640px)                  -->
   <!-- ═══════════════════════════════════════════ -->
-  <div class="flex items-center gap-2 sm:hidden pl-1 pr-0.5">
-    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/20">
-      <Timer class="h-4 w-4" />
+  <div class="flex items-center gap-3 sm:hidden pl-2 pr-1">
+    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 shadow-sm">
+      <Timer class="h-5 w-5" />
     </div>
     
-    <span class="font-mono text-lg font-black">{formattedTime}</span>
+    <span class="font-mono text-xl font-black drop-shadow-sm">{formattedTime}</span>
     
-    <div class="mx-1 h-5 w-px bg-white/20"></div>
+    <div class="mx-1 h-6 w-px bg-white/20"></div>
     
     <button
       onclick={onGoToSeats}
-      class="flex h-8 w-8 items-center justify-center rounded-full bg-white/20 text-white transition active:scale-95"
+      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition active:scale-95"
       title="Quay lại chọn ghế"
     >
-      <ArrowLeft class="h-4 w-4 -rotate-180" />
+      <ArrowLeft class="h-5 w-5" />
     </button>
-
+    
     <button
       onclick={onExitClick}
-      class="flex h-8 w-8 items-center justify-center rounded-full bg-black/20 text-white transition active:scale-95"
-      title="Thoát phiên"
+      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
+      title="Hủy xếp hàng"
     >
-      <LogOut class="h-4 w-4" />
+      <LogOut class="h-5 w-5" />
     </button>
   </div>
 

--- a/src/lib/components/customer/queue/QueueHolding.svelte
+++ b/src/lib/components/customer/queue/QueueHolding.svelte
@@ -19,33 +19,39 @@
   <!-- ═══════════════════════════════════════════ -->
   <div class="flex items-center sm:hidden text-white">
     <!-- Clickable area to undock when docked -->
-    <button 
+    <button
+      type="button"
       class="flex items-center gap-3"
       onclick={isDocked ? onUndock : undefined}
-      aria-label={isDocked ? "Mở rộng widget" : undefined}
+      disabled={!isDocked}
+      aria-label="Mở rộng widget"
     >
       <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white shadow-md">
         <Timer class="h-5 w-5 text-orange-600" />
       </div>
-      
+
       <span class="font-mono text-xl font-black drop-shadow-sm">{formattedTime}</span>
     </button>
-    
+
     {#if !isDocked}
       <div class="flex items-center gap-3 overflow-hidden pl-3" transition:slide={{ axis: 'x', duration: 250 }}>
         <div class="h-6 w-px bg-white/20 shrink-0"></div>
-        
+
         <button
+          type="button"
           onclick={onGoToSeats}
           class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition active:scale-95"
+          aria-label="Quay lại chọn ghế"
           title="Quay lại chọn ghế"
         >
           <ArrowLeft class="h-5 w-5" />
         </button>
-        
+
         <button
+          type="button"
           onclick={onExitClick}
           class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
+          aria-label="Thoát phiên chọn ghế"
           title="Hủy xếp hàng"
         >
           <LogOut class="h-5 w-5" />
@@ -60,7 +66,7 @@
   <div class="hidden sm:block relative">
     <!-- Decoration -->
     <div class="absolute -top-10 -left-10 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
-    
+
     <div class="mb-3 flex items-center gap-3">
       <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
         <Timer class="h-5 w-5" />
@@ -83,14 +89,17 @@
     <div transition:slide>
       <div class="flex gap-2">
         <button
+          type="button"
           onclick={onGoToSeats}
           class="action-btn flex-1 rounded-xl bg-white py-2.5 text-xs font-bold text-orange-600 transition-all hover:bg-white/90 active:scale-95"
         >
           Quay lại chọn ghế
         </button>
         <button
+          type="button"
           onclick={onExitClick}
           class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/20 text-white transition hover:bg-red-500 hover:text-white"
+          aria-label="Thoát phiên chọn ghế"
           title="Hủy xếp hàng"
         >
           <LogOut class="h-4 w-4" />

--- a/src/lib/components/customer/queue/QueueHolding.svelte
+++ b/src/lib/components/customer/queue/QueueHolding.svelte
@@ -1,43 +1,57 @@
 <script lang="ts">
   import { Timer, ArrowLeft, LogOut } from 'lucide-svelte';
+  import { slide } from 'svelte/transition';
   import { queueStore } from '$lib/stores/queue.svelte';
 
   type Props = {
+    isDocked?: boolean;
+    onUndock?: () => void;
     formattedTime: string;
     onGoToSeats: () => void;
     onExitClick: () => void;
   };
-  let { formattedTime, onGoToSeats, onExitClick }: Props = $props();
+  let { isDocked = false, onUndock, formattedTime, onGoToSeats, onExitClick }: Props = $props();
 </script>
 
 <div class="bg-orange-500 p-2 sm:p-4 text-white shadow-inner sm:shadow-none">
   <!-- ═══════════════════════════════════════════ -->
   <!-- MOBILE PILL VIEW (< 640px)                  -->
   <!-- ═══════════════════════════════════════════ -->
-  <div class="flex items-center gap-3 sm:hidden pl-2 pr-1">
-    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 shadow-sm">
-      <Timer class="h-5 w-5" />
-    </div>
-    
-    <span class="font-mono text-xl font-black drop-shadow-sm">{formattedTime}</span>
-    
-    <div class="mx-1 h-6 w-px bg-white/20"></div>
-    
-    <button
-      onclick={onGoToSeats}
-      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition active:scale-95"
-      title="Quay lại chọn ghế"
+  <div class="flex items-center sm:hidden text-white">
+    <!-- Clickable area to undock when docked -->
+    <button 
+      class="flex items-center gap-3"
+      onclick={isDocked ? onUndock : undefined}
+      aria-label={isDocked ? "Mở rộng widget" : undefined}
     >
-      <ArrowLeft class="h-5 w-5" />
+      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white shadow-md">
+        <Timer class="h-5 w-5 text-orange-600" />
+      </div>
+      
+      <span class="font-mono text-xl font-black drop-shadow-sm">{formattedTime}</span>
     </button>
     
-    <button
-      onclick={onExitClick}
-      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
-      title="Hủy xếp hàng"
-    >
-      <LogOut class="h-5 w-5" />
-    </button>
+    {#if !isDocked}
+      <div class="flex items-center gap-3 overflow-hidden pl-3" transition:slide={{ axis: 'x', duration: 250 }}>
+        <div class="h-6 w-px bg-white/20 shrink-0"></div>
+        
+        <button
+          onclick={onGoToSeats}
+          class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition active:scale-95"
+          title="Quay lại chọn ghế"
+        >
+          <ArrowLeft class="h-5 w-5" />
+        </button>
+        
+        <button
+          onclick={onExitClick}
+          class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
+          title="Hủy xếp hàng"
+        >
+          <LogOut class="h-5 w-5" />
+        </button>
+      </div>
+    {/if}
   </div>
 
   <!-- ═══════════════════════════════════════════ -->
@@ -66,21 +80,22 @@
     </div>
 
     <!-- Actions -->
-    <div class="flex gap-2">
-      <button
-        onclick={onGoToSeats}
-        class="flex-1 rounded-xl bg-white py-2.5 text-xs font-bold text-orange-600 transition-all hover:bg-white/90 active:scale-95"
-      >
-        <ArrowLeft class="mr-1 inline-block h-3.5 w-3.5 -rotate-180" />
-        Quay lại chọn ghế
-      </button>
-      <button
-        onclick={onExitClick}
-        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-black/20 text-white transition hover:bg-black/30"
-        title="Thoát phiên chọn ghế"
-      >
-        <LogOut class="h-4 w-4" />
-      </button>
+    <div transition:slide>
+      <div class="flex gap-2">
+        <button
+          onclick={onGoToSeats}
+          class="action-btn flex-1 rounded-xl bg-white py-2.5 text-xs font-bold text-orange-600 transition-all hover:bg-white/90 active:scale-95"
+        >
+          Quay lại chọn ghế
+        </button>
+        <button
+          onclick={onExitClick}
+          class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/20 text-white transition hover:bg-red-500 hover:text-white"
+          title="Hủy xếp hàng"
+        >
+          <LogOut class="h-4 w-4" />
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/lib/components/customer/queue/QueueReady.svelte
+++ b/src/lib/components/customer/queue/QueueReady.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { AlertCircle } from 'lucide-svelte';
+  import { queueStore } from '$lib/stores/queue.svelte';
+
+  interface Props {
+    formattedTime: string;
+    onGoToSeats: () => void;
+  }
+  let { formattedTime, onGoToSeats }: Props = $props();
+</script>
+
+<div class="bg-emerald-600 p-4 text-white">
+  <!-- Pulse ring decoration -->
+  <div class="absolute -top-6 -right-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+
+  <div class="relative">
+    <div class="mb-3 flex items-center gap-3">
+      <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
+        <AlertCircle class="h-5 w-5" />
+      </div>
+      <div>
+        <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">Đã tới lượt!</p>
+        {#if queueStore.eventTitle}
+          <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Countdown -->
+    <div class="mb-3 text-center">
+      <p class="text-xs opacity-80">Xác nhận trong vòng</p>
+      <p class="font-mono text-4xl font-black tabular-nums">{formattedTime}</p>
+    </div>
+
+    <button
+      onclick={onGoToSeats}
+      class="w-full animate-pulse rounded-xl bg-white py-3 text-sm font-bold text-emerald-700 shadow-lg shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95"
+    >
+      VÀO CHỌN GHẾ NGAY →
+    </button>
+  </div>
+</div>

--- a/src/lib/components/customer/queue/QueueReady.svelte
+++ b/src/lib/components/customer/queue/QueueReady.svelte
@@ -9,25 +9,25 @@
   let { formattedTime, onGoToSeats }: Props = $props();
 </script>
 
-<div class="bg-emerald-600 p-1.5 sm:p-4 text-white">
+<div class="bg-emerald-600 p-2 sm:p-4 text-white shadow-inner sm:shadow-none">
   <!-- ═══════════════════════════════════════════ -->
   <!-- MOBILE PILL VIEW (< 640px)                  -->
   <!-- ═══════════════════════════════════════════ -->
-  <div class="flex items-center gap-2 sm:hidden pl-1 pr-0.5">
-    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/20">
-      <AlertCircle class="h-4 w-4" />
+  <div class="flex items-center gap-3 sm:hidden pl-2 pr-1">
+    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 shadow-sm">
+      <AlertCircle class="h-5 w-5" />
     </div>
     
-    <span class="font-mono text-lg font-black">{formattedTime}</span>
+    <span class="font-mono text-xl font-black drop-shadow-sm">{formattedTime}</span>
     
-    <div class="mx-1 h-5 w-px bg-white/20"></div>
+    <div class="mx-1 h-6 w-px bg-white/20"></div>
     
     <button
       onclick={onGoToSeats}
-      class="flex h-8 w-auto px-3 items-center justify-center gap-1.5 rounded-full bg-white text-xs font-bold text-emerald-700 animate-pulse transition active:scale-95"
+      class="flex h-10 w-auto px-4 items-center justify-center gap-1.5 rounded-full bg-white text-sm font-bold text-emerald-700 animate-pulse shadow-md transition active:scale-95"
     >
       CHỌN GHẾ
-      <ArrowRight class="h-3 w-3" />
+      <ArrowRight class="h-4 w-4" />
     </button>
   </div>
 

--- a/src/lib/components/customer/queue/QueueReady.svelte
+++ b/src/lib/components/customer/queue/QueueReady.svelte
@@ -1,34 +1,48 @@
 <script lang="ts">
   import { AlertCircle, ArrowRight } from 'lucide-svelte';
+  import { slide } from 'svelte/transition';
   import { queueStore } from '$lib/stores/queue.svelte';
 
   type Props = {
+    isDocked?: boolean;
+    onUndock?: () => void;
     formattedTime: string;
     onGoToSeats: () => void;
   };
-  let { formattedTime, onGoToSeats }: Props = $props();
+  let { isDocked = false, onUndock, formattedTime, onGoToSeats }: Props = $props();
 </script>
 
 <div class="bg-emerald-600 p-2 sm:p-4 text-white shadow-inner sm:shadow-none">
   <!-- ═══════════════════════════════════════════ -->
   <!-- MOBILE PILL VIEW (< 640px)                  -->
   <!-- ═══════════════════════════════════════════ -->
-  <div class="flex items-center gap-3 sm:hidden pl-2 pr-1">
-    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 shadow-sm">
-      <AlertCircle class="h-5 w-5" />
-    </div>
-    
-    <span class="font-mono text-xl font-black drop-shadow-sm">{formattedTime}</span>
-    
-    <div class="mx-1 h-6 w-px bg-white/20"></div>
-    
-    <button
-      onclick={onGoToSeats}
-      class="flex h-10 w-auto px-4 items-center justify-center gap-1.5 rounded-full bg-white text-sm font-bold text-emerald-700 animate-pulse shadow-md transition active:scale-95"
+  <div class="flex items-center sm:hidden text-white">
+    <!-- Clickable area to undock when docked -->
+    <button 
+      class="flex items-center gap-3"
+      onclick={isDocked ? onUndock : undefined}
+      aria-label={isDocked ? "Mở rộng widget" : undefined}
     >
-      CHỌN GHẾ
-      <ArrowRight class="h-4 w-4" />
+      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white shadow-md">
+        <AlertCircle class="h-5 w-5 text-green-600" />
+      </div>
+      
+      <span class="font-mono text-xl font-black drop-shadow-sm">{formattedTime}</span>
     </button>
+    
+    {#if !isDocked}
+      <div class="flex items-center gap-3 overflow-hidden pl-3" transition:slide={{ axis: 'x', duration: 250 }}>
+        <div class="h-6 w-px bg-white/20 shrink-0"></div>
+        
+        <button
+          onclick={onGoToSeats}
+          class="action-btn flex h-10 w-auto px-4 shrink-0 items-center justify-center gap-1.5 rounded-full bg-white text-sm font-bold text-emerald-700 animate-pulse shadow-md transition active:scale-95"
+        >
+          CHỌN GHẾ
+          <ArrowRight class="h-4 w-4" />
+        </button>
+      </div>
+    {/if}
   </div>
 
   <!-- ═══════════════════════════════════════════ -->
@@ -58,7 +72,7 @@
 
     <button
       onclick={onGoToSeats}
-      class="w-full animate-pulse rounded-xl bg-white py-3 text-sm font-bold text-emerald-700 shadow-lg shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95"
+      class="action-btn w-full animate-pulse rounded-xl bg-white py-3 text-sm font-bold text-emerald-700 shadow-lg shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95"
     >
       VÀO CHỌN GHẾ NGAY →
     </button>

--- a/src/lib/components/customer/queue/QueueReady.svelte
+++ b/src/lib/components/customer/queue/QueueReady.svelte
@@ -1,27 +1,51 @@
 <script lang="ts">
-  import { AlertCircle } from 'lucide-svelte';
+  import { AlertCircle, ArrowRight } from 'lucide-svelte';
   import { queueStore } from '$lib/stores/queue.svelte';
 
-  interface Props {
+  type Props = {
     formattedTime: string;
     onGoToSeats: () => void;
-  }
+  };
   let { formattedTime, onGoToSeats }: Props = $props();
 </script>
 
-<div class="bg-emerald-600 p-4 text-white">
-  <!-- Pulse ring decoration -->
-  <div class="absolute -top-6 -right-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+<div class="bg-emerald-600 p-1.5 sm:p-4 text-white">
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- MOBILE PILL VIEW (< 640px)                  -->
+  <!-- ═══════════════════════════════════════════ -->
+  <div class="flex items-center gap-2 sm:hidden pl-1 pr-0.5">
+    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/20">
+      <AlertCircle class="h-4 w-4" />
+    </div>
+    
+    <span class="font-mono text-lg font-black">{formattedTime}</span>
+    
+    <div class="mx-1 h-5 w-px bg-white/20"></div>
+    
+    <button
+      onclick={onGoToSeats}
+      class="flex h-8 w-auto px-3 items-center justify-center gap-1.5 rounded-full bg-white text-xs font-bold text-emerald-700 animate-pulse transition active:scale-95"
+    >
+      CHỌN GHẾ
+      <ArrowRight class="h-3 w-3" />
+    </button>
+  </div>
 
-  <div class="relative">
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- DESKTOP CARD VIEW (>= 640px)                -->
+  <!-- ═══════════════════════════════════════════ -->
+  <div class="hidden sm:block relative">
+    <!-- Pulse ring decoration -->
+    <div class="absolute -top-10 -right-10 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+    
     <div class="mb-3 flex items-center gap-3">
       <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
         <AlertCircle class="h-5 w-5" />
       </div>
-      <div>
+      <div class="min-w-0 flex-1">
         <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">Đã tới lượt!</p>
         {#if queueStore.eventTitle}
-          <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
+          <p class="truncate text-xs font-semibold">{queueStore.eventTitle}</p>
         {/if}
       </div>
     </div>

--- a/src/lib/components/customer/queue/QueueWaiting.svelte
+++ b/src/lib/components/customer/queue/QueueWaiting.svelte
@@ -1,48 +1,81 @@
 <script lang="ts">
-  import { Loader2, X } from 'lucide-svelte';
+  import { Loader2, X, Maximize2 } from 'lucide-svelte';
   import { queueStore } from '$lib/stores/queue.svelte';
 
-  interface Props {
+  type Props = {
     onExpand: () => void;
     onExitClick: () => void;
-  }
+  };
   let { onExpand, onExitClick }: Props = $props();
 </script>
 
-<div class="bg-surface-container-highest p-4">
-  <!-- Header -->
-  <div class="mb-3 flex items-center gap-3">
-    <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10">
-      <Loader2 class="h-5 w-5 animate-spin text-primary" />
+<div class="bg-surface-container-highest p-1.5 sm:p-4">
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- MOBILE PILL VIEW (< 640px)                  -->
+  <!-- ═══════════════════════════════════════════ -->
+  <div class="flex items-center gap-2 sm:hidden pl-1 pr-0.5">
+    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
+      <Loader2 class="h-4 w-4 animate-spin text-primary" />
     </div>
-    <div class="min-w-0 flex-1">
-      <p class="text-[10px] font-bold tracking-widest text-primary uppercase">Đang xếp hàng</p>
-      {#if queueStore.eventTitle}
-        <p class="truncate text-xs font-semibold text-foreground">{queueStore.eventTitle}</p>
-      {/if}
-    </div>
-  </div>
-
-  <!-- Position badge -->
-  <div class="mb-3 flex items-center justify-center gap-2 rounded-xl bg-surface-container p-3">
-    <span class="text-sm text-muted-foreground">Vị trí của bạn:</span>
-    <span class="text-2xl font-black text-primary">#{queueStore.position}</span>
-  </div>
-
-  <!-- Actions -->
-  <div class="flex gap-2">
+    <span class="font-mono text-lg font-black text-primary">#{queueStore.position}</span>
+    
+    <div class="mx-1 h-5 w-px bg-outline-variant/30"></div>
+    
     <button
       onclick={onExpand}
-      class="flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
+      class="flex h-8 w-8 items-center justify-center rounded-full bg-surface-container-high text-muted-foreground transition active:scale-95"
+      title="Phóng to"
     >
-      Phóng to phòng chờ
+      <Maximize2 class="h-4 w-4" />
     </button>
+    
     <button
       onclick={onExitClick}
-      class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+      class="flex h-8 w-8 items-center justify-center rounded-full bg-destructive/10 text-destructive transition active:scale-95"
       title="Hủy xếp hàng"
     >
       <X class="h-4 w-4" />
     </button>
+  </div>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- DESKTOP CARD VIEW (>= 640px)                -->
+  <!-- ═══════════════════════════════════════════ -->
+  <div class="hidden sm:block">
+    <!-- Header -->
+    <div class="mb-3 flex items-center gap-3">
+      <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+        <Loader2 class="h-5 w-5 animate-spin text-primary" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <p class="text-[10px] font-bold tracking-widest text-primary uppercase">Đang xếp hàng</p>
+        {#if queueStore.eventTitle}
+          <p class="truncate text-xs font-semibold text-foreground">{queueStore.eventTitle}</p>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Position badge -->
+    <div class="mb-3 flex items-center justify-center gap-2 rounded-xl bg-surface-container p-3">
+      <span class="text-sm text-muted-foreground">Vị trí của bạn:</span>
+      <span class="text-2xl font-black text-primary">#{queueStore.position}</span>
+    </div>
+
+    <!-- Actions -->
+    <div class="flex gap-2">
+      <button
+        onclick={onExpand}
+        class="flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
+      >
+        Phóng to phòng chờ
+      </button>
+      <button
+        onclick={onExitClick}
+        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+        title="Hủy xếp hàng"
+      >
+        <X class="h-4 w-4" />
+      </button>
+    </div>
   </div>
 </div>

--- a/src/lib/components/customer/queue/QueueWaiting.svelte
+++ b/src/lib/components/customer/queue/QueueWaiting.svelte
@@ -18,32 +18,38 @@
   <!-- ═══════════════════════════════════════════ -->
   <div class="flex items-center sm:hidden text-white">
     <!-- Clickable area to undock when docked -->
-    <button 
+    <button
+      type="button"
       class="flex items-center gap-3"
       onclick={isDocked ? onUndock : undefined}
-      aria-label={isDocked ? "Mở rộng widget" : undefined}
+      disabled={!isDocked}
+      aria-label="Mở rộng widget"
     >
       <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white shadow-md">
         <Loader2 class="h-5 w-5 animate-spin text-primary" />
       </div>
       <span class="font-mono text-xl font-black text-white drop-shadow-sm">#{queueStore.position}</span>
     </button>
-    
+
     {#if !isDocked}
       <div class="flex items-center gap-3 overflow-hidden pl-3" transition:slide={{ axis: 'x', duration: 250 }}>
         <div class="h-6 w-px bg-white/20 shrink-0"></div>
-        
+
         <button
+          type="button"
           onclick={onExpand}
           class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-white/30 active:scale-95"
+          aria-label="Phóng to phòng chờ"
           title="Phóng to"
         >
           <Maximize2 class="h-5 w-5" />
         </button>
-        
+
         <button
+          type="button"
           onclick={onExitClick}
           class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
+          aria-label="Hủy xếp hàng"
           title="Hủy xếp hàng"
         >
           <X class="h-5 w-5" />
@@ -78,14 +84,17 @@
     <!-- Actions -->
     <div class="flex gap-2">
       <button
+        type="button"
         onclick={onExpand}
         class="action-btn flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
       >
         Phóng to phòng chờ
       </button>
       <button
+        type="button"
         onclick={onExitClick}
         class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+        aria-label="Hủy xếp hàng"
         title="Hủy xếp hàng"
       >
         <X class="h-4 w-4" />

--- a/src/lib/components/customer/queue/QueueWaiting.svelte
+++ b/src/lib/components/customer/queue/QueueWaiting.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { Loader2, X } from 'lucide-svelte';
+  import { queueStore } from '$lib/stores/queue.svelte';
+
+  interface Props {
+    onExpand: () => void;
+    onExitClick: () => void;
+  }
+  let { onExpand, onExitClick }: Props = $props();
+</script>
+
+<div class="bg-surface-container-highest p-4">
+  <!-- Header -->
+  <div class="mb-3 flex items-center gap-3">
+    <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+      <Loader2 class="h-5 w-5 animate-spin text-primary" />
+    </div>
+    <div class="min-w-0 flex-1">
+      <p class="text-[10px] font-bold tracking-widest text-primary uppercase">Đang xếp hàng</p>
+      {#if queueStore.eventTitle}
+        <p class="truncate text-xs font-semibold text-foreground">{queueStore.eventTitle}</p>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Position badge -->
+  <div class="mb-3 flex items-center justify-center gap-2 rounded-xl bg-surface-container p-3">
+    <span class="text-sm text-muted-foreground">Vị trí của bạn:</span>
+    <span class="text-2xl font-black text-primary">#{queueStore.position}</span>
+  </div>
+
+  <!-- Actions -->
+  <div class="flex gap-2">
+    <button
+      onclick={onExpand}
+      class="flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
+    >
+      Phóng to phòng chờ
+    </button>
+    <button
+      onclick={onExitClick}
+      class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+      title="Hủy xếp hàng"
+    >
+      <X class="h-4 w-4" />
+    </button>
+  </div>
+</div>

--- a/src/lib/components/customer/queue/QueueWaiting.svelte
+++ b/src/lib/components/customer/queue/QueueWaiting.svelte
@@ -9,32 +9,32 @@
   let { onExpand, onExitClick }: Props = $props();
 </script>
 
-<div class="bg-surface-container-highest p-1.5 sm:p-4">
+<div class="bg-primary sm:bg-surface-container-highest p-2 sm:p-4 shadow-inner sm:shadow-none">
   <!-- ═══════════════════════════════════════════ -->
   <!-- MOBILE PILL VIEW (< 640px)                  -->
   <!-- ═══════════════════════════════════════════ -->
-  <div class="flex items-center gap-2 sm:hidden pl-1 pr-0.5">
-    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
-      <Loader2 class="h-4 w-4 animate-spin text-primary" />
+  <div class="flex items-center gap-3 sm:hidden pl-2 pr-1 text-white">
+    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 shadow-sm">
+      <Loader2 class="h-5 w-5 animate-spin text-white" />
     </div>
-    <span class="font-mono text-lg font-black text-primary">#{queueStore.position}</span>
+    <span class="font-mono text-xl font-black text-white drop-shadow-sm">#{queueStore.position}</span>
     
-    <div class="mx-1 h-5 w-px bg-outline-variant/30"></div>
+    <div class="mx-1 h-6 w-px bg-white/20"></div>
     
     <button
       onclick={onExpand}
-      class="flex h-8 w-8 items-center justify-center rounded-full bg-surface-container-high text-muted-foreground transition active:scale-95"
+      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-white/30 active:scale-95"
       title="Phóng to"
     >
-      <Maximize2 class="h-4 w-4" />
+      <Maximize2 class="h-5 w-5" />
     </button>
     
     <button
       onclick={onExitClick}
-      class="flex h-8 w-8 items-center justify-center rounded-full bg-destructive/10 text-destructive transition active:scale-95"
+      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
       title="Hủy xếp hàng"
     >
-      <X class="h-4 w-4" />
+      <X class="h-5 w-5" />
     </button>
   </div>
 

--- a/src/lib/components/customer/queue/QueueWaiting.svelte
+++ b/src/lib/components/customer/queue/QueueWaiting.svelte
@@ -1,41 +1,55 @@
 <script lang="ts">
   import { Loader2, X, Maximize2 } from 'lucide-svelte';
+  import { slide } from 'svelte/transition';
   import { queueStore } from '$lib/stores/queue.svelte';
 
   type Props = {
+    isDocked?: boolean;
+    onUndock?: () => void;
     onExpand: () => void;
     onExitClick: () => void;
   };
-  let { onExpand, onExitClick }: Props = $props();
+  let { isDocked = false, onUndock, onExpand, onExitClick }: Props = $props();
 </script>
 
 <div class="bg-primary sm:bg-surface-container-highest p-2 sm:p-4 shadow-inner sm:shadow-none">
   <!-- ═══════════════════════════════════════════ -->
   <!-- MOBILE PILL VIEW (< 640px)                  -->
   <!-- ═══════════════════════════════════════════ -->
-  <div class="flex items-center gap-3 sm:hidden pl-2 pr-1 text-white">
-    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 shadow-sm">
-      <Loader2 class="h-5 w-5 animate-spin text-white" />
-    </div>
-    <span class="font-mono text-xl font-black text-white drop-shadow-sm">#{queueStore.position}</span>
-    
-    <div class="mx-1 h-6 w-px bg-white/20"></div>
-    
-    <button
-      onclick={onExpand}
-      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-white/30 active:scale-95"
-      title="Phóng to"
+  <div class="flex items-center sm:hidden text-white">
+    <!-- Clickable area to undock when docked -->
+    <button 
+      class="flex items-center gap-3"
+      onclick={isDocked ? onUndock : undefined}
+      aria-label={isDocked ? "Mở rộng widget" : undefined}
     >
-      <Maximize2 class="h-5 w-5" />
+      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white shadow-md">
+        <Loader2 class="h-5 w-5 animate-spin text-primary" />
+      </div>
+      <span class="font-mono text-xl font-black text-white drop-shadow-sm">#{queueStore.position}</span>
     </button>
     
-    <button
-      onclick={onExitClick}
-      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
-      title="Hủy xếp hàng"
-    >
-      <X class="h-5 w-5" />
-    </button>
+    {#if !isDocked}
+      <div class="flex items-center gap-3 overflow-hidden pl-3" transition:slide={{ axis: 'x', duration: 250 }}>
+        <div class="h-6 w-px bg-white/20 shrink-0"></div>
+        
+        <button
+          onclick={onExpand}
+          class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-white/30 active:scale-95"
+          title="Phóng to"
+        >
+          <Maximize2 class="h-5 w-5" />
+        </button>
+        
+        <button
+          onclick={onExitClick}
+          class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/20 text-white shadow-sm transition hover:bg-red-500 hover:text-white active:scale-95"
+          title="Hủy xếp hàng"
+        >
+          <X class="h-5 w-5" />
+        </button>
+      </div>
+    {/if}
   </div>
 
   <!-- ═══════════════════════════════════════════ -->
@@ -65,13 +79,13 @@
     <div class="flex gap-2">
       <button
         onclick={onExpand}
-        class="flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
+        class="action-btn flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
       >
         Phóng to phòng chờ
       </button>
       <button
         onclick={onExitClick}
-        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+        class="action-btn flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
         title="Hủy xếp hàng"
       >
         <X class="h-4 w-4" />

--- a/src/lib/components/customer/queue/QueueWidget.svelte
+++ b/src/lib/components/customer/queue/QueueWidget.svelte
@@ -179,16 +179,21 @@
     let newX = startOffset.x + dx;
     let newY = startOffset.y + dy;
 
-    // Boundary constraints
-    // Base position is fixed right-5 (20px) and bottom-5 (20px)
-    const baseLeft = window.innerWidth - 40 - 320; // 40 = 20px left + 20px right padding
-    const baseTop = window.innerHeight - 20 - widgetEl.offsetHeight;
+    // Boundary constraints based on responsive padding
+    const isMobile = window.innerWidth < 640;
+    const paddingX = isMobile ? 16 : 20; // right-4 vs right-5
+    const paddingBottom = isMobile ? 96 : 20; // bottom-24 (96px) vs bottom-5 (20px) to avoid mobile bottom navigation
+    const paddingTop = isMobile ? 60 : 80;
+    const widgetWidth = widgetEl.offsetWidth;
+
+    const baseLeft = window.innerWidth - paddingX * 2 - widgetWidth;
+    const baseTop = window.innerHeight - paddingBottom - widgetEl.offsetHeight;
 
     const minX = -baseLeft; // touches left padding limit
     const maxX = 0; // touches right padding limit
     
-    // Ensure 80px top padding to avoid header
-    const minY = -(baseTop - 80); 
+    // Ensure top padding to avoid header
+    const minY = -(baseTop - paddingTop); 
     const maxY = 0; // touches bottom padding limit
 
     const safeMinX = Math.min(minX, maxX);
@@ -212,7 +217,11 @@
 
     // iPhone AssistiveTouch Snapping Logic
     // Snap to the nearest vertical edge (Left or Right)
-    const baseLeft = window.innerWidth - 40 - 320;
+    const isMobile = window.innerWidth < 640;
+    const paddingX = isMobile ? 16 : 20;
+    const widgetWidth = widgetEl.offsetWidth;
+    
+    const baseLeft = window.innerWidth - paddingX * 2 - widgetWidth;
     const minX = -baseLeft;
     const maxX = 0;
 
@@ -232,12 +241,12 @@
 {#if shouldShow}
   <div
     transition:fly={{ y: 20, duration: 300 }}
-    class="fixed right-5 bottom-5 z-50 w-[320px]"
+    class="fixed right-4 bottom-24 z-50 w-max sm:right-5 sm:bottom-5 sm:w-[320px]"
   >
     <div
       bind:this={widgetEl}
       role="none"
-      class="w-full overflow-hidden rounded-2xl ring-1 ring-black/10 backdrop-blur-sm
+      class="w-full overflow-hidden rounded-full sm:rounded-2xl ring-1 ring-black/10 backdrop-blur-sm
              {isDragging ? 'cursor-grabbing shadow-2xl ring-black/20' : 'cursor-grab shadow-xl'}"
       style="
         transform: translate({dragOffset.x}px, {dragOffset.y}px) scale({isDragging ? 1.02 : 1});

--- a/src/lib/components/customer/queue/QueueWidget.svelte
+++ b/src/lib/components/customer/queue/QueueWidget.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { queueStore } from '$lib/stores/queue.svelte';
   import { fly } from 'svelte/transition';
   import QueueWaiting from './QueueWaiting.svelte';
@@ -98,7 +99,7 @@
   function expandQueue() {
     const eventId = queueStore.eventId;
     queueStore.isMinimized = false;
-    if (eventId) goto(`/events/${eventId}/queue`);
+    if (eventId) goto(resolve(`/events/${eventId}/queue`));
   }
 
   /**
@@ -117,27 +118,36 @@
         const res = await fetch(`/api/events/${eventId}/queue/confirm`, {
           method: 'POST',
         });
+
         if (res.ok) {
           const { data } = await res.json();
-          // Stage the confirm data; the /seats page commits it on mount to avoid the orange flash.
+          // Stage the confirm data
           queueStore.setPendingConfirm(data.expiresAt, data.token);
+
           if (showId) {
-            goto(`/events/${eventId}/shows/${showId}/seats`);
+            goto(resolve(`/events/${eventId}/shows/${showId}/seats`));
           } else {
-            goto(`/events/${eventId}`);
+            goto(resolve(`/events/${eventId}`));
           }
+          return;
+        } else {
+          console.error('[Widget] Confirm failed: Server rejected');
+          alert('Không thể xác nhận slot. Có thể phiên của bạn đã hết hạn. Vui lòng tải lại trang!');
           return;
         }
       } catch (err) {
-        console.error('[Widget Confirm Error]', err);
+        console.error('[Widget] Confirm Error:', err);
+        alert('Lỗi kết nối mạng. Vui lòng thử lại!');
+        return;
       }
     }
 
-    // Fallback: navigate directly if already holding.
-    if (showId && eventId) {
-      goto(`/events/${eventId}/shows/${showId}/seats`);
-    } else if (eventId) {
-      goto(`/events/${eventId}`);
+    if (queueStore.status === 'holding') {
+      if (showId && eventId) {
+        goto(resolve(`/events/${eventId}/shows/${showId}/seats`));
+      } else if (eventId) {
+        goto(resolve(`/events/${eventId}`));
+      }
     }
   }
 
@@ -175,7 +185,7 @@
 
     const dx = e.clientX - startPointer.x;
     const dy = e.clientY - startPointer.y;
-    
+
     let newX = startOffset.x + dx;
     let newY = startOffset.y + dy;
 
@@ -191,9 +201,9 @@
 
     const minX = -baseLeft; // touches left padding limit
     const maxX = 0; // touches right padding limit
-    
+
     // Ensure top padding to avoid header
-    const minY = -(baseTop - paddingTop); 
+    const minY = -(baseTop - paddingTop);
     const maxY = 0; // touches bottom padding limit
 
     const safeMinX = Math.min(minX, maxX);
@@ -220,7 +230,7 @@
     const isMobile = window.innerWidth < 640;
     const paddingX = isMobile ? 16 : 20;
     const widgetWidth = widgetEl.offsetWidth;
-    
+
     const baseLeft = window.innerWidth - paddingX * 2 - widgetWidth;
     const minX = -baseLeft;
     const maxX = 0;

--- a/src/lib/components/customer/queue/QueueWidget.svelte
+++ b/src/lib/components/customer/queue/QueueWidget.svelte
@@ -1,0 +1,328 @@
+<!-- src/lib/components/customer/queue/QueueWidget.svelte -->
+<script lang="ts">
+  import { page } from '$app/state';
+  import { goto } from '$app/navigation';
+  import { queueStore } from '$lib/stores/queue.svelte';
+  import { AlertCircle, ArrowLeft, Loader2, LogOut, Timer, X } from 'lucide-svelte';
+
+  /** Remaining seconds, derived from `queueStore.expiresAt`. */
+  let timeLeft = $state(0);
+  /** Controls visibility of the "Exit session" confirmation modal. */
+  let showExitConfirm = $state(false);
+  /** True while the leave-queue API call is in-flight. */
+  let isLeaving = $state(false);
+
+  /**
+   * Countdown effect — ticks every second while the queue is active.
+   * When the timer reaches zero in `ready` or `holding` state, the session
+   * is automatically marked as `missed` and the queue slot is released.
+   */
+  $effect(() => {
+    if (queueStore.status === 'idle' || queueStore.status === 'missed') return;
+
+    const update = () => {
+      if (queueStore.expiresAt) {
+        timeLeft = Math.max(0, Math.floor((queueStore.expiresAt - Date.now()) / 1000));
+        // Timer expired — auto-leave to release the slot for the next user.
+        if (timeLeft === 0 && (queueStore.status === 'ready' || queueStore.status === 'holding')) {
+          queueStore.status = 'missed';
+          queueStore.leave();
+        }
+      }
+    };
+
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  });
+
+  /**
+   * Background polling effect — runs every 5 seconds while the user is
+   * in `waiting` status. Ensures the widget updates to `ready` (green)
+   * even when the user has navigated away from the /queue page.
+   */
+  $effect(() => {
+    if (queueStore.status !== 'waiting' || !queueStore.eventId) return;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/events/${queueStore.eventId}/queue/status`);
+        if (!res.ok) return;
+        const { data } = await res.json();
+
+        if (data.status === 'active') {
+          queueStore.status = 'ready';
+          queueStore.expiresAt = data.expiresAt;
+          if (data.token) queueStore.token = data.token;
+        } else if (data.status === 'waiting') {
+          queueStore.position = data.position;
+        } else if (data.status === 'none') {
+          queueStore.clear();
+        }
+      } catch (err) {
+        console.error('[Widget Poll Error]', err);
+      }
+    };
+
+    const interval = setInterval(poll, 5000);
+    return () => clearInterval(interval);
+  });
+
+  function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  /**
+   * Determines whether the floating widget should be rendered.
+   *
+   * Hidden when:
+   * - Status is `idle` or `missed` (no active queue).
+   * - Status is `waiting` and the user is already on a `/queue` page (full-screen view).
+   * - Status is `holding` and the user is on the `/seats` page (no need to overlay).
+   * - The URL ends with `/queue` to avoid duplicate UI.
+   */
+  let shouldShow = $derived(
+    queueStore.status !== 'idle' &&
+      queueStore.status !== 'missed' &&
+      !(queueStore.status === 'waiting' && page.url.pathname.includes('/queue')) &&
+      !(queueStore.status === 'holding' && page.url.pathname.includes('/seats')) &&
+      !page.url.pathname.endsWith('/queue'),
+  );
+
+  /** Expands the widget back to the full-screen queue page. */
+  function expandQueue() {
+    const eventId = queueStore.eventId;
+    queueStore.isMinimized = false;
+    if (eventId) goto(`/events/${eventId}/queue`);
+  }
+
+  /**
+   * Navigates the user to the seat selection page.
+   *
+   * When the status is `ready`, this first calls the `/confirm` API to
+   * extend the slot from 60s (grace period) to 5 minutes (holding session).
+   * Uses `pendingConfirm` to avoid the orange widget flashing during navigation.
+   */
+  async function goToSeats() {
+    const eventId = queueStore.eventId;
+    const showId = queueStore.showId;
+
+    if (queueStore.status === 'ready' && eventId) {
+      try {
+        const res = await fetch(`/api/events/${eventId}/queue/confirm`, {
+          method: 'POST',
+        });
+        if (res.ok) {
+          const { data } = await res.json();
+          // Stage the confirm data; the /seats page commits it on mount to avoid the orange flash.
+          queueStore.setPendingConfirm(data.expiresAt, data.token);
+          if (showId) {
+            goto(`/events/${eventId}/shows/${showId}/seats`);
+          } else {
+            goto(`/events/${eventId}`);
+          }
+          return;
+        }
+      } catch (err) {
+        console.error('[Widget Confirm Error]', err);
+      }
+    }
+
+    // Fallback: navigate directly if already holding.
+    if (showId && eventId) {
+      goto(`/events/${eventId}/shows/${showId}/seats`);
+    } else if (eventId) {
+      goto(`/events/${eventId}`);
+    }
+  }
+
+  async function handleLeave() {
+    isLeaving = true;
+    showExitConfirm = false;
+    await queueStore.leave();
+    isLeaving = false;
+  }
+</script>
+
+{#if shouldShow}
+  <div
+    class="fixed right-5 bottom-5 z-50 w-[320px] animate-in overflow-hidden rounded-2xl
+           shadow-2xl ring-1 ring-black/10
+           backdrop-blur-sm duration-300 fade-in slide-in-from-bottom-4"
+  >
+    <!-- ────────────────── WAITING (Thu nhỏ) ────────────────── -->
+    {#if queueStore.status === 'waiting'}
+      <div class="bg-surface-container-highest p-4">
+        <!-- Header -->
+        <div class="mb-3 flex items-center gap-3">
+          <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+            <Loader2 class="h-5 w-5 animate-spin text-primary" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <p class="text-[10px] font-bold tracking-widest text-primary uppercase">
+              Đang xếp hàng
+            </p>
+            {#if queueStore.eventTitle}
+              <p class="truncate text-xs font-semibold text-foreground">{queueStore.eventTitle}</p>
+            {/if}
+          </div>
+        </div>
+
+        <!-- Position badge -->
+        <div
+          class="mb-3 flex items-center justify-center gap-2 rounded-xl bg-surface-container p-3"
+        >
+          <span class="text-sm text-muted-foreground">Vị trí của bạn:</span>
+          <span class="text-2xl font-black text-primary">#{queueStore.position}</span>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex gap-2">
+          <button
+            onclick={expandQueue}
+            class="flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
+          >
+            Phóng to phòng chờ
+          </button>
+          <button
+            onclick={() => (showExitConfirm = true)}
+            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+            title="Hủy xếp hàng"
+          >
+            <X class="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <!-- ────────────────── READY (Grace Period 60s) ────────────────── -->
+    {:else if queueStore.status === 'ready'}
+      <div class="bg-emerald-600 p-4 text-white">
+        <!-- Pulse ring decoration -->
+        <div class="absolute -top-6 -right-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+
+        <div class="relative">
+          <div class="mb-3 flex items-center gap-3">
+            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
+              <AlertCircle class="h-5 w-5" />
+            </div>
+            <div>
+              <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">Đã tới lượt!</p>
+              {#if queueStore.eventTitle}
+                <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
+              {/if}
+            </div>
+          </div>
+
+          <!-- Countdown -->
+          <div class="mb-3 text-center">
+            <p class="text-xs opacity-80">Xác nhận trong vòng</p>
+            <p class="font-mono text-4xl font-black tabular-nums">
+              {formatTime(timeLeft)}
+            </p>
+          </div>
+
+          <button
+            onclick={goToSeats}
+            class="w-full animate-pulse rounded-xl bg-white py-3 text-sm font-bold text-emerald-700
+                   shadow-lg shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95"
+          >
+            VÀO CHỌN GHẾ NGAY →
+          </button>
+        </div>
+      </div>
+
+      <!-- ────────────────── HOLDING (Bảo vệ phiên 5 phút) ────────────────── -->
+    {:else if queueStore.status === 'holding'}
+      <div class="bg-orange-500 p-4 text-white">
+        <!-- Decoration -->
+        <div class="absolute -top-6 -left-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
+
+        <div class="relative">
+          <div class="mb-3 flex items-center gap-3">
+            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
+              <Timer class="h-5 w-5" />
+            </div>
+            <div>
+              <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">
+                Phiên chọn ghế
+              </p>
+              {#if queueStore.eventTitle}
+                <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
+              {/if}
+            </div>
+          </div>
+
+          <!-- Countdown -->
+          <div class="mb-3 flex items-center justify-between rounded-xl bg-black/20 px-4 py-2.5">
+            <span class="text-xs opacity-80">Hết hạn sau:</span>
+            <span class="font-mono text-2xl font-black tabular-nums">{formatTime(timeLeft)}</span>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex gap-2">
+            <button
+              onclick={goToSeats}
+              class="flex-1 rounded-xl bg-white py-2.5 text-xs font-bold text-orange-600 transition-all hover:bg-white/90 active:scale-95"
+            >
+              <ArrowLeft class="mr-1 inline-block h-3.5 w-3.5 -rotate-180" />
+              Quay lại chọn ghế
+            </button>
+            <button
+              onclick={() => (showExitConfirm = true)}
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-black/20 text-white transition hover:bg-black/30"
+              title="Thoát phiên chọn ghế"
+            >
+              <LogOut class="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<!-- ────────────────── EXIT CONFIRM MODAL ────────────────── -->
+{#if showExitConfirm}
+  <div class="fixed inset-0 z-[70] flex items-center justify-center p-4">
+    <!-- Backdrop -->
+    <button
+      class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+      onclick={() => (showExitConfirm = false)}
+      aria-label="Đóng"
+    ></button>
+
+    <div
+      class="relative z-10 w-full max-w-sm animate-in overflow-hidden rounded-2xl bg-surface shadow-2xl duration-200 zoom-in-95"
+    >
+      <div class="p-6">
+        <h3 class="mb-2 font-heading text-lg font-bold text-foreground">
+          {queueStore.status === 'holding' ? 'Thoát phiên chọn ghế?' : 'Hủy xếp hàng?'}
+        </h3>
+        <p class="text-sm text-muted-foreground">
+          {#if queueStore.status === 'holding'}
+            Bạn sẽ mất quyền giữ slot và phải xếp hàng lại từ đầu nếu muốn mua vé.
+          {:else}
+            Bạn sẽ mất vị trí #{queueStore.position} trong hàng chờ. Hành động này không thể hoàn tác.
+          {/if}
+        </p>
+      </div>
+      <div class="flex gap-3 border-t border-outline-variant/20 px-6 py-4">
+        <button
+          onclick={() => (showExitConfirm = false)}
+          class="flex-1 rounded-xl bg-surface-container-highest px-4 py-2.5 text-sm font-semibold text-foreground transition hover:bg-surface-container-high active:scale-95"
+        >
+          Ở lại
+        </button>
+        <button
+          onclick={handleLeave}
+          disabled={isLeaving}
+          class="flex-1 rounded-xl bg-destructive px-4 py-2.5 text-sm font-bold text-white transition hover:opacity-90 active:scale-95 disabled:opacity-50"
+        >
+          {isLeaving ? 'Đang xử lý...' : 'Xác nhận thoát'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/customer/queue/QueueWidget.svelte
+++ b/src/lib/components/customer/queue/QueueWidget.svelte
@@ -3,7 +3,9 @@
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
   import { queueStore } from '$lib/stores/queue.svelte';
-  import { AlertCircle, ArrowLeft, Loader2, LogOut, Timer, X } from 'lucide-svelte';
+  import QueueWaiting from './QueueWaiting.svelte';
+  import QueueReady from './QueueReady.svelte';
+  import QueueHolding from './QueueHolding.svelte';
 
   /** Remaining seconds, derived from `queueStore.expiresAt`. */
   let timeLeft = $state(0);
@@ -152,133 +154,16 @@
            shadow-2xl ring-1 ring-black/10
            backdrop-blur-sm duration-300 fade-in slide-in-from-bottom-4"
   >
-    <!-- ────────────────── WAITING (Thu nhỏ) ────────────────── -->
     {#if queueStore.status === 'waiting'}
-      <div class="bg-surface-container-highest p-4">
-        <!-- Header -->
-        <div class="mb-3 flex items-center gap-3">
-          <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10">
-            <Loader2 class="h-5 w-5 animate-spin text-primary" />
-          </div>
-          <div class="min-w-0 flex-1">
-            <p class="text-[10px] font-bold tracking-widest text-primary uppercase">
-              Đang xếp hàng
-            </p>
-            {#if queueStore.eventTitle}
-              <p class="truncate text-xs font-semibold text-foreground">{queueStore.eventTitle}</p>
-            {/if}
-          </div>
-        </div>
-
-        <!-- Position badge -->
-        <div
-          class="mb-3 flex items-center justify-center gap-2 rounded-xl bg-surface-container p-3"
-        >
-          <span class="text-sm text-muted-foreground">Vị trí của bạn:</span>
-          <span class="text-2xl font-black text-primary">#{queueStore.position}</span>
-        </div>
-
-        <!-- Actions -->
-        <div class="flex gap-2">
-          <button
-            onclick={expandQueue}
-            class="flex-1 rounded-xl bg-primary py-2.5 text-xs font-bold text-primary-foreground transition-all hover:opacity-90 active:scale-95"
-          >
-            Phóng to phòng chờ
-          </button>
-          <button
-            onclick={() => (showExitConfirm = true)}
-            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-surface-container text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
-            title="Hủy xếp hàng"
-          >
-            <X class="h-4 w-4" />
-          </button>
-        </div>
-      </div>
-
-      <!-- ────────────────── READY (Grace Period 60s) ────────────────── -->
+      <QueueWaiting onExpand={expandQueue} onExitClick={() => (showExitConfirm = true)} />
     {:else if queueStore.status === 'ready'}
-      <div class="bg-emerald-600 p-4 text-white">
-        <!-- Pulse ring decoration -->
-        <div class="absolute -top-6 -right-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
-
-        <div class="relative">
-          <div class="mb-3 flex items-center gap-3">
-            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
-              <AlertCircle class="h-5 w-5" />
-            </div>
-            <div>
-              <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">Đã tới lượt!</p>
-              {#if queueStore.eventTitle}
-                <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
-              {/if}
-            </div>
-          </div>
-
-          <!-- Countdown -->
-          <div class="mb-3 text-center">
-            <p class="text-xs opacity-80">Xác nhận trong vòng</p>
-            <p class="font-mono text-4xl font-black tabular-nums">
-              {formatTime(timeLeft)}
-            </p>
-          </div>
-
-          <button
-            onclick={goToSeats}
-            class="w-full animate-pulse rounded-xl bg-white py-3 text-sm font-bold text-emerald-700
-                   shadow-lg shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95"
-          >
-            VÀO CHỌN GHẾ NGAY →
-          </button>
-        </div>
-      </div>
-
-      <!-- ────────────────── HOLDING (Bảo vệ phiên 5 phút) ────────────────── -->
+      <QueueReady formattedTime={formatTime(timeLeft)} onGoToSeats={goToSeats} />
     {:else if queueStore.status === 'holding'}
-      <div class="bg-orange-500 p-4 text-white">
-        <!-- Decoration -->
-        <div class="absolute -top-6 -left-6 h-24 w-24 rounded-full bg-white/10 blur-xl"></div>
-
-        <div class="relative">
-          <div class="mb-3 flex items-center gap-3">
-            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white/20">
-              <Timer class="h-5 w-5" />
-            </div>
-            <div>
-              <p class="text-[10px] font-bold tracking-widest uppercase opacity-80">
-                Phiên chọn ghế
-              </p>
-              {#if queueStore.eventTitle}
-                <p class="max-w-[180px] truncate text-xs font-semibold">{queueStore.eventTitle}</p>
-              {/if}
-            </div>
-          </div>
-
-          <!-- Countdown -->
-          <div class="mb-3 flex items-center justify-between rounded-xl bg-black/20 px-4 py-2.5">
-            <span class="text-xs opacity-80">Hết hạn sau:</span>
-            <span class="font-mono text-2xl font-black tabular-nums">{formatTime(timeLeft)}</span>
-          </div>
-
-          <!-- Actions -->
-          <div class="flex gap-2">
-            <button
-              onclick={goToSeats}
-              class="flex-1 rounded-xl bg-white py-2.5 text-xs font-bold text-orange-600 transition-all hover:bg-white/90 active:scale-95"
-            >
-              <ArrowLeft class="mr-1 inline-block h-3.5 w-3.5 -rotate-180" />
-              Quay lại chọn ghế
-            </button>
-            <button
-              onclick={() => (showExitConfirm = true)}
-              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-black/20 text-white transition hover:bg-black/30"
-              title="Thoát phiên chọn ghế"
-            >
-              <LogOut class="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-      </div>
+      <QueueHolding
+        formattedTime={formatTime(timeLeft)}
+        onGoToSeats={goToSeats}
+        onExitClick={() => (showExitConfirm = true)}
+      />
     {/if}
   </div>
 {/if}

--- a/src/lib/components/customer/queue/QueueWidget.svelte
+++ b/src/lib/components/customer/queue/QueueWidget.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
   import { queueStore } from '$lib/stores/queue.svelte';
+  import { fly } from 'svelte/transition';
   import QueueWaiting from './QueueWaiting.svelte';
   import QueueReady from './QueueReady.svelte';
   import QueueHolding from './QueueHolding.svelte';
@@ -146,25 +147,120 @@
     await queueStore.leave();
     isLeaving = false;
   }
+
+  // --- Drag and Drop State ---
+  let isDragging = $state(false);
+  let dragOffset = $state({ x: 0, y: 0 });
+  let startPointer = { x: 0, y: 0 };
+  let startOffset = { x: 0, y: 0 };
+  let widgetEl: HTMLElement | undefined = $state();
+
+  function handlePointerDown(e: PointerEvent) {
+    // Only allow left click dragging and ignore clicks on buttons
+    if (e.button !== 0) return;
+    const target = e.target as HTMLElement;
+    if (target.closest('button')) return;
+
+    isDragging = true;
+    startPointer = { x: e.clientX, y: e.clientY };
+    startOffset = { ...dragOffset };
+
+    const el = e.currentTarget as HTMLElement;
+    el.setPointerCapture(e.pointerId);
+  }
+
+  function handlePointerMove(e: PointerEvent) {
+    if (!isDragging || !widgetEl) return;
+    e.preventDefault(); // Prevent text selection/scrolling while dragging
+
+    const dx = e.clientX - startPointer.x;
+    const dy = e.clientY - startPointer.y;
+    
+    let newX = startOffset.x + dx;
+    let newY = startOffset.y + dy;
+
+    // Boundary constraints
+    // Base position is fixed right-5 (20px) and bottom-5 (20px)
+    const baseLeft = window.innerWidth - 40 - 320; // 40 = 20px left + 20px right padding
+    const baseTop = window.innerHeight - 20 - widgetEl.offsetHeight;
+
+    const minX = -baseLeft; // touches left padding limit
+    const maxX = 0; // touches right padding limit
+    
+    // Ensure 80px top padding to avoid header
+    const minY = -(baseTop - 80); 
+    const maxY = 0; // touches bottom padding limit
+
+    const safeMinX = Math.min(minX, maxX);
+    const safeMaxX = Math.max(minX, maxX);
+    const safeMinY = Math.min(minY, maxY);
+    const safeMaxY = Math.max(minY, maxY);
+
+    newX = Math.max(safeMinX, Math.min(newX, safeMaxX));
+    newY = Math.max(safeMinY, Math.min(newY, safeMaxY));
+
+    dragOffset = { x: newX, y: newY };
+  }
+
+  function handlePointerUp(e: PointerEvent) {
+    if (!isDragging) return;
+    isDragging = false;
+    const el = e.currentTarget as HTMLElement;
+    el.releasePointerCapture(e.pointerId);
+
+    if (!widgetEl) return;
+
+    // iPhone AssistiveTouch Snapping Logic
+    // Snap to the nearest vertical edge (Left or Right)
+    const baseLeft = window.innerWidth - 40 - 320;
+    const minX = -baseLeft;
+    const maxX = 0;
+
+    const safeMinX = Math.min(minX, maxX);
+    const safeMaxX = Math.max(minX, maxX);
+
+    const midX = (safeMinX + safeMaxX) / 2;
+    const targetX = dragOffset.x > midX ? safeMaxX : safeMinX;
+
+    dragOffset = {
+      x: targetX,
+      y: dragOffset.y // keep current Y
+    };
+  }
 </script>
 
 {#if shouldShow}
   <div
-    class="fixed right-5 bottom-5 z-50 w-[320px] animate-in overflow-hidden rounded-2xl
-           shadow-2xl ring-1 ring-black/10
-           backdrop-blur-sm duration-300 fade-in slide-in-from-bottom-4"
+    transition:fly={{ y: 20, duration: 300 }}
+    class="fixed right-5 bottom-5 z-50 w-[320px]"
   >
-    {#if queueStore.status === 'waiting'}
-      <QueueWaiting onExpand={expandQueue} onExitClick={() => (showExitConfirm = true)} />
-    {:else if queueStore.status === 'ready'}
-      <QueueReady formattedTime={formatTime(timeLeft)} onGoToSeats={goToSeats} />
-    {:else if queueStore.status === 'holding'}
-      <QueueHolding
-        formattedTime={formatTime(timeLeft)}
-        onGoToSeats={goToSeats}
-        onExitClick={() => (showExitConfirm = true)}
-      />
-    {/if}
+    <div
+      bind:this={widgetEl}
+      role="none"
+      class="w-full overflow-hidden rounded-2xl ring-1 ring-black/10 backdrop-blur-sm
+             {isDragging ? 'cursor-grabbing shadow-2xl ring-black/20' : 'cursor-grab shadow-xl'}"
+      style="
+        transform: translate({dragOffset.x}px, {dragOffset.y}px) scale({isDragging ? 1.02 : 1});
+        touch-action: none;
+        transition: {isDragging ? 'none' : 'transform 0.5s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease'};
+      "
+      onpointerdown={handlePointerDown}
+      onpointermove={handlePointerMove}
+      onpointerup={handlePointerUp}
+      onpointercancel={handlePointerUp}
+    >
+      {#if queueStore.status === 'waiting'}
+        <QueueWaiting onExpand={expandQueue} onExitClick={() => (showExitConfirm = true)} />
+      {:else if queueStore.status === 'ready'}
+        <QueueReady formattedTime={formatTime(timeLeft)} onGoToSeats={goToSeats} />
+      {:else if queueStore.status === 'holding'}
+        <QueueHolding
+          formattedTime={formatTime(timeLeft)}
+          onGoToSeats={goToSeats}
+          onExitClick={() => (showExitConfirm = true)}
+        />
+      {/if}
+    </div>
   </div>
 {/if}
 

--- a/src/lib/components/customer/queue/QueueWidget.svelte
+++ b/src/lib/components/customer/queue/QueueWidget.svelte
@@ -5,6 +5,7 @@
   import { resolve } from '$app/paths';
   import { queueStore } from '$lib/stores/queue.svelte';
   import { fly } from 'svelte/transition';
+  import { tick } from 'svelte';
   import QueueWaiting from './QueueWaiting.svelte';
   import QueueReady from './QueueReady.svelte';
   import QueueHolding from './QueueHolding.svelte';
@@ -29,8 +30,7 @@
         timeLeft = Math.max(0, Math.floor((queueStore.expiresAt - Date.now()) / 1000));
         // Timer expired — auto-leave to release the slot for the next user.
         if (timeLeft === 0 && (queueStore.status === 'ready' || queueStore.status === 'holding')) {
-          queueStore.status = 'missed';
-          queueStore.leave();
+          queueStore.leave({ navigate: false });
         }
       }
     };
@@ -152,26 +152,52 @@
   }
 
   async function handleLeave() {
+    if (isLeaving) return;
     isLeaving = true;
-    showExitConfirm = false;
-    await queueStore.leave();
-    isLeaving = false;
+    try {
+      await queueStore.leave();
+      showExitConfirm = false;
+    } finally {
+      isLeaving = false;
+    }
   }
 
   // --- Drag and Drop State ---
   let isDragging = $state(false);
+  let hasMoved = $state(false);
   let dragOffset = $state({ x: 0, y: 0 });
   let startPointer = { x: 0, y: 0 };
   let startOffset = { x: 0, y: 0 };
   let widgetEl: HTMLElement | undefined = $state();
 
+  // --- Docking State ---
+  let isDocked = $state(false);
+  let anchorSide = $state<'left' | 'right'>('right');
+  let disableTransition = $state(false);
+
+  // Auto-undock when status changes
+  let prevStatus = $state(queueStore.status);
+  $effect(() => {
+    if (queueStore.status !== prevStatus) {
+      if (queueStore.status !== 'idle' && queueStore.status !== 'missed') {
+        isDocked = false; // Auto pop-out on status change
+      }
+      prevStatus = queueStore.status;
+    }
+  });
+
+  function handleUndock() {
+    isDocked = false;
+  }
+
   function handlePointerDown(e: PointerEvent) {
     // Only allow left click dragging and ignore clicks on buttons
     if (e.button !== 0) return;
     const target = e.target as HTMLElement;
-    if (target.closest('button')) return;
+    if (target.closest('.action-btn')) return;
 
     isDragging = true;
+    hasMoved = false;
     startPointer = { x: e.clientX, y: e.clientY };
     startOffset = { ...dragOffset };
 
@@ -181,10 +207,17 @@
 
   function handlePointerMove(e: PointerEvent) {
     if (!isDragging || !widgetEl) return;
-    e.preventDefault(); // Prevent text selection/scrolling while dragging
-
+    
     const dx = e.clientX - startPointer.x;
     const dy = e.clientY - startPointer.y;
+
+    if (!hasMoved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
+      hasMoved = true;
+    }
+
+    if (!hasMoved) return;
+
+    e.preventDefault(); // Prevent text selection/scrolling while dragging
 
     let newX = startOffset.x + dx;
     let newY = startOffset.y + dy;
@@ -199,8 +232,14 @@
     const baseLeft = window.innerWidth - paddingX * 2 - widgetWidth;
     const baseTop = window.innerHeight - paddingBottom - widgetEl.offsetHeight;
 
-    const minX = -baseLeft; // touches left padding limit
-    const maxX = 0; // touches right padding limit
+    let minX, maxX;
+    if (anchorSide === 'right') {
+      minX = -baseLeft; // touches left padding limit
+      maxX = 0; // touches right padding limit
+    } else {
+      minX = 0; // touches left padding limit
+      maxX = baseLeft; // touches right padding limit
+    }
 
     // Ensure top padding to avoid header
     const minY = -(baseTop - paddingTop);
@@ -225,6 +264,11 @@
 
     if (!widgetEl) return;
 
+    if (!hasMoved) {
+      // It was just a tap, do not execute docking logic
+      return;
+    }
+
     // iPhone AssistiveTouch Snapping Logic
     // Snap to the nearest vertical edge (Left or Right)
     const isMobile = window.innerWidth < 640;
@@ -232,8 +276,14 @@
     const widgetWidth = widgetEl.offsetWidth;
 
     const baseLeft = window.innerWidth - paddingX * 2 - widgetWidth;
-    const minX = -baseLeft;
-    const maxX = 0;
+    let minX, maxX;
+    if (anchorSide === 'right') {
+      minX = -baseLeft;
+      maxX = 0;
+    } else {
+      minX = 0;
+      maxX = baseLeft;
+    }
 
     const safeMinX = Math.min(minX, maxX);
     const safeMaxX = Math.max(minX, maxX);
@@ -245,13 +295,45 @@
       x: targetX,
       y: dragOffset.y // keep current Y
     };
+
+    if (isMobile) {
+      if (anchorSide === 'right' && targetX === safeMinX) {
+        // Snapped to left edge
+        setTimeout(async () => {
+          disableTransition = true;
+          anchorSide = 'left';
+          dragOffset.x = 0;
+          await tick(); // Wait for Svelte to apply state to DOM
+          void widgetEl?.offsetHeight; // Force browser reflow to apply styles synchronously
+          disableTransition = false;
+          isDocked = true;
+        }, 500); // Wait for transform animation
+      } else if (anchorSide === 'left' && targetX === safeMaxX) {
+        // Snapped to right edge
+        setTimeout(async () => {
+          disableTransition = true;
+          anchorSide = 'right';
+          dragOffset.x = 0;
+          await tick();
+          void widgetEl?.offsetHeight;
+          disableTransition = false;
+          isDocked = true;
+        }, 500);
+      } else {
+        // Snapped back to current edge
+        setTimeout(() => {
+          isDocked = true;
+        }, 500);
+      }
+    }
   }
 </script>
 
 {#if shouldShow}
   <div
     transition:fly={{ y: 20, duration: 300 }}
-    class="fixed right-4 bottom-24 z-50 w-max sm:right-5 sm:bottom-5 sm:w-[320px]"
+    class="fixed bottom-24 z-50 w-max sm:bottom-5 sm:w-[320px] sm:!right-5 sm:!left-auto"
+    style="{anchorSide === 'left' ? 'left: 16px; right: auto;' : 'right: 16px; left: auto;'}"
   >
     <div
       bind:this={widgetEl}
@@ -261,7 +343,7 @@
       style="
         transform: translate({dragOffset.x}px, {dragOffset.y}px) scale({isDragging ? 1.02 : 1});
         touch-action: none;
-        transition: {isDragging ? 'none' : 'transform 0.5s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease'};
+        transition: {isDragging || disableTransition ? 'none' : 'transform 0.5s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease'};
       "
       onpointerdown={handlePointerDown}
       onpointermove={handlePointerMove}
@@ -269,11 +351,13 @@
       onpointercancel={handlePointerUp}
     >
       {#if queueStore.status === 'waiting'}
-        <QueueWaiting onExpand={expandQueue} onExitClick={() => (showExitConfirm = true)} />
+        <QueueWaiting {isDocked} onUndock={handleUndock} onExpand={expandQueue} onExitClick={() => (showExitConfirm = true)} />
       {:else if queueStore.status === 'ready'}
-        <QueueReady formattedTime={formatTime(timeLeft)} onGoToSeats={goToSeats} />
+        <QueueReady {isDocked} onUndock={handleUndock} formattedTime={formatTime(timeLeft)} onGoToSeats={goToSeats} />
       {:else if queueStore.status === 'holding'}
         <QueueHolding
+          {isDocked}
+          onUndock={handleUndock}
           formattedTime={formatTime(timeLeft)}
           onGoToSeats={goToSeats}
           onExitClick={() => (showExitConfirm = true)}

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -104,6 +104,18 @@ export const Errors = {
   // MQ
   MQ_UNAVAILABLE: new AppError('MQ_UNAVAILABLE', 503, 'Hệ thống tạm thời bận, vui lòng thử lại.'),
 
+  // Virtual Queue
+  QUEUE_SESSION_EXPIRED: new AppError(
+    'QUEUE_SESSION_EXPIRED',
+    410,
+    'Phiên hàng chờ đã hết hạn hoặc không tồn tại',
+  ),
+  QUEUE_ALREADY_JOINED: new AppError(
+    'QUEUE_ALREADY_JOINED',
+    409,
+    'Bạn đang tham gia hàng chờ của một sự kiện khác',
+  ),
+
   // General
   NOT_FOUND: new AppError('NOT_FOUND', 404, 'Không tìm thấy'),
   INTERNAL_ERROR: new AppError('INTERNAL_ERROR', 500, 'Đã có lỗi xảy ra, vui lòng thử lại'),

--- a/src/lib/server/services/queue.service.ts
+++ b/src/lib/server/services/queue.service.ts
@@ -21,8 +21,10 @@ export const queueService = {
       const waitingKey = `waiting_queue:${eventId}`;
       const now = Date.now();
       const maxUsers = config.maxConcurrentUsers ?? 200;
-      const expiresAt = now + config.accessTokenDuration * 1000;
-      const activeTtl = config.accessTokenDuration + 5;
+      // Users promoted immediately (no waiting) receive the full holding duration (5 min).
+      const initialDuration = config.accessTokenDuration;
+      const expiresAt = now + initialDuration * 1000;
+      const activeTtl = initialDuration + 5;
       const waitingTtl = 3600;
 
       // ── Atomic Lua script: cross-queue guard, already‑active check,
@@ -92,7 +94,7 @@ export const queueService = {
         throwError(Errors.EVENT_NOT_AVAILABLE, 'Bạn đang tham gia hàng chờ của một sự kiện khác');
       }
 
-      // Already active
+      // code 2: User already has an active (unexpired) slot — return its remaining time.
       if (code === 2) {
         const activeExpiresAt = value;
         const expiresInSeconds = Math.max(1, Math.ceil((activeExpiresAt - now) / 1000));
@@ -100,18 +102,18 @@ export const queueService = {
         return { status: 'active', expiresAt: activeExpiresAt, token };
       }
 
-      // Already waiting — no SET, just return position
+      // code 3: User is already in the waiting list — return their current position.
       if (code === 3) {
         return { status: 'waiting', position: value };
       }
 
-      // Newly promoted to active
+      // code 1: User was promoted immediately to active — mint a full-duration seat token.
       if (code === 1) {
         const token = await encryptSeatToken({ userId, eventId }, config.accessTokenDuration);
         return { status: 'active', expiresAt: value, token };
       }
 
-      // Newly enqueued as waiting
+      // code 0: User was added to the waiting list.
       return { status: 'waiting', position: value };
     });
   },
@@ -121,21 +123,24 @@ export const queueService = {
       const activeKey = `active_users:${eventId}`;
       const now = Date.now();
 
-      // Atomic check: Ensures user is strictly active before minting fresh token.
-      // Does NOT extend the slot — only mints a token for the remaining time.
-      // Sets user_current_queue TTL to (remaining_active_time + 5s grace) so it
-      // never outlives the ZSET score by more than the grace window.
+      /**
+       * Atomic Lua script: verifies the user is still active (within the grace period),
+       * then extends the slot score in the sorted set and refreshes the TTL on
+       * `user_current_queue` to grant the full holding duration.
+       */
       const luaScript = `
         local raw = redis.call('ZSCORE', KEYS[1], ARGV[1])
         local currentScore = raw and tonumber(raw) or 0
         local now = tonumber(ARGV[2])
         local eventId = ARGV[3]
-        local grace = tonumber(ARGV[4])
+        local holdingDuration = tonumber(ARGV[4]) -- e.g. 300 seconds
 
+        -- Only extend if the slot is still valid (within grace period).
         if currentScore > now then
-          local ttl = math.max(1, math.ceil((currentScore - now) / 1000) + grace)
-          redis.call('SET', KEYS[2], eventId, 'EX', ttl)
-          return currentScore
+          local newExpiresAt = now + (holdingDuration * 1000)
+          redis.call('ZADD', KEYS[1], newExpiresAt, ARGV[1])
+          redis.call('SET', KEYS[2], eventId, 'EX', holdingDuration + 5)
+          return newExpiresAt
         end
 
         return 0
@@ -144,11 +149,11 @@ export const queueService = {
       const activeExpiresAt = await redis.eval<[string, number, string, number], number>(
         luaScript,
         [activeKey, `user_current_queue:${userId}`],
-        [String(userId), now, String(eventId), 5],
+        [String(userId), now, String(eventId), config.accessTokenDuration],
       );
 
       if (!activeExpiresAt) {
-        throwError(Errors.FORBIDDEN, 'Slot của bạn không tồn tại hoặc đã hết hạn');
+        throwError(Errors.FORBIDDEN, 'Your queue slot does not exist or has already expired.');
       }
 
       const expiresInSeconds = Math.max(1, Math.ceil((activeExpiresAt - now) / 1000));
@@ -162,8 +167,12 @@ export const queueService = {
     return await withRedisErrorHandling(async () => {
       const userCurrentKey = `user_current_queue:${userId}`;
 
-      // Atomic: only remove if user_current_queue still points to this event
-      // at the moment of deletion. Prevents cross-queue race conditions.
+      /**
+       * Atomic Lua script: removes the user from both the active sorted set and the
+       * waiting sorted set, but only if `user_current_queue` still maps to this event.
+       * Prevents cross-queue race conditions where a stale cleanup could evict a user
+       * who has already joined a different event.
+       */
       const leaveQueueScript = `
         if redis.call('GET', KEYS[1]) == ARGV[1] then
           redis.call('DEL', KEYS[1])
@@ -197,7 +206,7 @@ export const queueService = {
         const token =
           expiresInSeconds <= 30
             ? await encryptSeatToken({ userId, eventId }, expiresInSeconds)
-            : null;
+            : null; // Re-use the existing token if more than 30s remain.
         return { status: 'active', expiresAt: activeScore, token };
       }
 

--- a/src/lib/server/services/queue.service.ts
+++ b/src/lib/server/services/queue.service.ts
@@ -135,12 +135,20 @@ export const queueService = {
         local now = tonumber(ARGV[2])
         local eventId = ARGV[3]
         local holdingDuration = tonumber(ARGV[4]) -- e.g. 300 seconds
+        local confirmedKey = KEYS[3]
 
         -- Only extend if the slot is still valid (within grace period).
         if currentScore > now then
+          -- If already confirmed, return the existing expiry without extending
+          local alreadyConfirmed = redis.call('GET', confirmedKey)
+          if alreadyConfirmed then
+            return currentScore
+          end
+
           local newExpiresAt = now + (holdingDuration * 1000)
           redis.call('ZADD', KEYS[1], newExpiresAt, ARGV[1])
           redis.call('SET', KEYS[2], eventId, 'EX', holdingDuration + 5)
+          redis.call('SET', confirmedKey, '1', 'EX', holdingDuration + 5)
           return newExpiresAt
         end
 
@@ -149,7 +157,7 @@ export const queueService = {
 
       const activeExpiresAt = await redis.eval<[string, number, string, number], number>(
         luaScript,
-        [activeKey, `user_current_queue:${userId}`],
+        [activeKey, `user_current_queue:${userId}`, `confirmed:${eventId}:${userId}`],
         [String(userId), now, String(eventId), config.accessTokenDuration],
       );
 
@@ -179,6 +187,7 @@ export const queueService = {
           redis.call('DEL', KEYS[1])
           redis.call('ZREM', KEYS[2], ARGV[2])
           redis.call('ZREM', KEYS[3], ARGV[2])
+          redis.call('DEL', KEYS[4])
           return 1
         end
         return 0
@@ -186,7 +195,12 @@ export const queueService = {
 
       await redis.eval<[string, string], number>(
         leaveQueueScript,
-        [userCurrentKey, `active_users:${eventId}`, `waiting_queue:${eventId}`],
+        [
+          userCurrentKey, 
+          `active_users:${eventId}`, 
+          `waiting_queue:${eventId}`,
+          `confirmed:${eventId}:${userId}`
+        ],
         [String(eventId), String(userId)],
       );
 

--- a/src/lib/server/services/queue.service.ts
+++ b/src/lib/server/services/queue.service.ts
@@ -21,8 +21,9 @@ export const queueService = {
       const waitingKey = `waiting_queue:${eventId}`;
       const now = Date.now();
       const maxUsers = config.maxConcurrentUsers ?? 200;
-      // Users promoted immediately (no waiting) receive the full holding duration (5 min).
-      const initialDuration = config.accessTokenDuration;
+      // Users promoted immediately (no waiting) receive a short grace period (60s).
+      // They must explicitly call /confirm to receive the full holding duration.
+      const initialDuration = 60;
       const expiresAt = now + initialDuration * 1000;
       const activeTtl = initialDuration + 5;
       const waitingTtl = 3600;
@@ -107,9 +108,9 @@ export const queueService = {
         return { status: 'waiting', position: value };
       }
 
-      // code 1: User was promoted immediately to active — mint a full-duration seat token.
+      // code 1: User was promoted immediately to active — mint a grace-period token.
       if (code === 1) {
-        const token = await encryptSeatToken({ userId, eventId }, config.accessTokenDuration);
+        const token = await encryptSeatToken({ userId, eventId }, initialDuration);
         return { status: 'active', expiresAt: value, token };
       }
 

--- a/src/lib/server/services/queue.service.ts
+++ b/src/lib/server/services/queue.service.ts
@@ -91,7 +91,7 @@ export const queueService = {
 
       // ── Dispatch based on return code ──
       if (code === -1) {
-        throwError(Errors.EVENT_NOT_AVAILABLE, 'Bạn đang tham gia hàng chờ của một sự kiện khác');
+        throwError(Errors.QUEUE_ALREADY_JOINED);
       }
 
       // code 2: User already has an active (unexpired) slot — return its remaining time.
@@ -153,7 +153,7 @@ export const queueService = {
       );
 
       if (!activeExpiresAt) {
-        throwError(Errors.FORBIDDEN, 'Your queue slot does not exist or has already expired.');
+        throwError(Errors.QUEUE_SESSION_EXPIRED);
       }
 
       const expiresInSeconds = Math.max(1, Math.ceil((activeExpiresAt - now) / 1000));
@@ -213,6 +213,12 @@ export const queueService = {
       const position = await redis.zrank(waitingKey, userId);
       if (position !== null) {
         return { status: 'waiting', position: position + 1 };
+      }
+
+      // Cross-queue check: If not in this event, check if they are in ANY event
+      const currentEventId = await redis.get(`user_current_queue:${userId}`);
+      if (currentEventId && Number(currentEventId) !== eventId) {
+        return { status: 'other', eventId: Number(currentEventId) };
       }
 
       return { status: 'none' };

--- a/src/lib/shared/schemas/event.schema.ts
+++ b/src/lib/shared/schemas/event.schema.ts
@@ -641,7 +641,7 @@ export type FormDraft = z.infer<typeof formDraftSchema>;
 // ── Event Query Schema (Public List API) ───────
 export const eventQuerySchema = z.object({
   q: z.string().optional(),
-  category: z.string().optional(), // Filter by category slug 
+  category: z.string().optional(), // Filter by category slug
   categoryId: z.coerce.number().int().positive().optional(), // Filter by category ID
   startDate: z
     .string()

--- a/src/lib/stores/queue.svelte.ts
+++ b/src/lib/stores/queue.svelte.ts
@@ -122,18 +122,21 @@ class QueueStore {
   }
 
   /**
-   * Leaves the queue: calls the DELETE API, clears local state, then navigates
-   * back to the event page (or home if eventId is unavailable).
+   * Leaves the queue: calls the DELETE API, clears local state, then optionally
+   * navigates back to the event page (or home if eventId is unavailable).
    */
-  async leave() {
+  async leave(options?: { navigate?: boolean }) {
+    const shouldNavigate = options?.navigate ?? true;
     const eventId = this.eventId;
     this.clear();
     if (!browser) return;
     await fetch(`/api/events/${eventId}/queue`, { method: 'DELETE' }).catch(() => {});
-    if (eventId) {
-      goto(resolve(`/events/${eventId}`));
-    } else {
-      goto(resolve('/'));
+    if (shouldNavigate) {
+      if (eventId) {
+        goto(resolve(`/events/${eventId}`));
+      } else {
+        goto(resolve('/'));
+      }
     }
   }
 

--- a/src/lib/stores/queue.svelte.ts
+++ b/src/lib/stores/queue.svelte.ts
@@ -1,0 +1,161 @@
+// src/lib/stores/queue.svelte.ts
+import { browser } from '$app/environment';
+import { goto } from '$app/navigation';
+
+/** Represents the possible lifecycle states of a virtual queue session. */
+export type QueueStatus = 'idle' | 'waiting' | 'ready' | 'holding' | 'missed';
+
+class QueueStore {
+  eventId = $state<number | null>(null);
+  eventTitle = $state<string>('');
+  showId = $state<number | null>(null);
+  status = $state<QueueStatus>('idle');
+  position = $state<number>(0);
+  /** Unix timestamp (ms) — deadline for the grace period or holding session. */
+  expiresAt = $state<number | null>(null);
+  isMinimized = $state<boolean>(false);
+  token = $state<string | null>(null);
+  /**
+   * Staged confirm payload — prevents the orange widget from flashing during
+   * navigation to the seats page. The seats page commits this on mount.
+   */
+  pendingConfirm = $state<{ expiresAt: number; token: string } | null>(null);
+
+  private initialized = false;
+
+  init() {
+    if (!browser || this.initialized) return;
+    this.initialized = true;
+
+    const saved = localStorage.getItem('tixtac_queue');
+    if (saved) {
+      try {
+        const data = JSON.parse(saved);
+        this.eventId = data.eventId ?? null;
+        this.eventTitle = data.eventTitle ?? '';
+        this.showId = data.showId ?? null;
+        this.status = data.status ?? 'idle';
+        this.position = data.position ?? 0;
+        this.expiresAt = data.expiresAt ?? null;
+        this.isMinimized = data.isMinimized ?? false;
+        this.token = data.token ?? null;
+
+        // If the session expired while the page was closed, reset to idle on restore.
+        if (
+          this.expiresAt &&
+          Date.now() > this.expiresAt &&
+          (this.status === 'ready' || this.status === 'holding')
+        ) {
+          this.clear();
+        }
+      } catch (e) {
+        console.error('Lỗi parse queue state:', e);
+        localStorage.removeItem('tixtac_queue');
+      }
+    }
+
+    $effect.root(() => {
+      /** Sync reactive state to localStorage on every change. */
+      $effect(() => {
+        localStorage.setItem(
+          'tixtac_queue',
+          JSON.stringify({
+            eventId: this.eventId,
+            eventTitle: this.eventTitle,
+            showId: this.showId,
+            status: this.status,
+            position: this.position,
+            expiresAt: this.expiresAt,
+            isMinimized: this.isMinimized,
+            token: this.token,
+          }),
+        );
+      });
+    });
+  }
+
+  clear() {
+    this.eventId = null;
+    this.eventTitle = '';
+    this.showId = null;
+    this.status = 'idle';
+    this.position = 0;
+    this.expiresAt = null;
+    this.token = null;
+    this.isMinimized = false;
+    this.pendingConfirm = null;
+    if (browser) {
+      localStorage.removeItem('tixtac_queue');
+    }
+  }
+
+  /**
+   * Stages confirm data after a successful `/confirm` API call.
+   * Does NOT immediately set `status` to `'holding'` to avoid the orange
+   * widget flash during navigation. The seats page commits this on mount.
+   *
+   * @param expiresAt - Unix timestamp (ms) when the holding session expires.
+   * @param token     - Signed seat-access token for the holding session.
+   */
+  setPendingConfirm(expiresAt: number, token: string) {
+    this.pendingConfirm = { expiresAt, token };
+  }
+
+  /**
+   * Commits the staged confirm data and transitions status to `'holding'`.
+   * Called from `seats/+page.svelte` on component mount.
+   */
+  commitHolding() {
+    if (this.pendingConfirm) {
+      this.status = 'holding';
+      this.expiresAt = this.pendingConfirm.expiresAt;
+      this.token = this.pendingConfirm.token;
+      this.pendingConfirm = null;
+    }
+  }
+
+  /**
+   * Leaves the queue: calls the DELETE API, clears local state, then navigates
+   * back to the event page (or home if eventId is unavailable).
+   */
+  async leave() {
+    const eventId = this.eventId;
+    this.clear();
+    if (!browser) return;
+    await fetch(`/api/events/${eventId}/queue`, { method: 'DELETE' }).catch(() => {});
+    if (eventId) {
+      goto(`/events/${eventId}`);
+    } else {
+      goto('/');
+    }
+  }
+
+  /**
+   * Checks whether the user is currently queued for a *different* event.
+   *
+   * @param targetEventId - The event the user is attempting to join.
+   * @returns `true` if a cross-queue conflict exists and the confirmation modal should be shown.
+   */
+  hasConflict(targetEventId: number): boolean {
+    return (
+      this.eventId !== null &&
+      this.eventId !== targetEventId &&
+      this.status !== 'idle' &&
+      this.status !== 'missed'
+    );
+  }
+
+  /**
+   * Leaves the current queue without navigating, freeing the slot so the
+   * user can immediately join a different event's queue.
+   */
+  async leaveForNewEvent() {
+    const oldEventId = this.eventId;
+    if (oldEventId) {
+      await fetch(`/api/events/${oldEventId}/queue`, { method: 'DELETE' }).catch(() => {});
+    }
+    this.clear();
+  }
+}
+
+export const queueStore = new QueueStore();

--- a/src/lib/stores/queue.svelte.ts
+++ b/src/lib/stores/queue.svelte.ts
@@ -1,7 +1,7 @@
 // src/lib/stores/queue.svelte.ts
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
-
+import { resolve } from '$app/paths';
 /** Represents the possible lifecycle states of a virtual queue session. */
 export type QueueStatus = 'idle' | 'waiting' | 'ready' | 'holding' | 'missed';
 
@@ -19,7 +19,7 @@ class QueueStore {
    * Staged confirm payload — prevents the orange widget from flashing during
    * navigation to the seats page. The seats page commits this on mount.
    */
-  pendingConfirm = $state<{ expiresAt: number; token: string } | null>(null);
+  pendingConfirm = $state<{ expiresAt: number; token?: string } | null>(null);
 
   private initialized = false;
 
@@ -28,6 +28,7 @@ class QueueStore {
     this.initialized = true;
 
     const saved = localStorage.getItem('tixtac_queue');
+    const savedToken = sessionStorage.getItem('tixtac_queue_token');
     if (saved) {
       try {
         const data = JSON.parse(saved);
@@ -38,7 +39,7 @@ class QueueStore {
         this.position = data.position ?? 0;
         this.expiresAt = data.expiresAt ?? null;
         this.isMinimized = data.isMinimized ?? false;
-        this.token = data.token ?? null;
+        this.token = savedToken ?? null;
 
         // If the session expired while the page was closed, reset to idle on restore.
         if (
@@ -67,9 +68,14 @@ class QueueStore {
             position: this.position,
             expiresAt: this.expiresAt,
             isMinimized: this.isMinimized,
-            token: this.token,
+            // Exclude token from localStorage to mitigate XSS exposure
           }),
         );
+        if (this.token) {
+          sessionStorage.setItem('tixtac_queue_token', this.token);
+        } else {
+          sessionStorage.removeItem('tixtac_queue_token');
+        }
       });
     });
   }
@@ -86,6 +92,7 @@ class QueueStore {
     this.pendingConfirm = null;
     if (browser) {
       localStorage.removeItem('tixtac_queue');
+      sessionStorage.removeItem('tixtac_queue_token');
     }
   }
 
@@ -97,7 +104,7 @@ class QueueStore {
    * @param expiresAt - Unix timestamp (ms) when the holding session expires.
    * @param token     - Signed seat-access token for the holding session.
    */
-  setPendingConfirm(expiresAt: number, token: string) {
+  setPendingConfirm(expiresAt: number, token?: string) {
     this.pendingConfirm = { expiresAt, token };
   }
 
@@ -109,7 +116,7 @@ class QueueStore {
     if (this.pendingConfirm) {
       this.status = 'holding';
       this.expiresAt = this.pendingConfirm.expiresAt;
-      this.token = this.pendingConfirm.token;
+      this.token = this.pendingConfirm.token ?? null;
       this.pendingConfirm = null;
     }
   }
@@ -124,9 +131,9 @@ class QueueStore {
     if (!browser) return;
     await fetch(`/api/events/${eventId}/queue`, { method: 'DELETE' }).catch(() => {});
     if (eventId) {
-      goto(`/events/${eventId}`);
+      goto(resolve(`/events/${eventId}`));
     } else {
-      goto('/');
+      goto(resolve('/'));
     }
   }
 

--- a/src/routes/(customer)/+layout.svelte
+++ b/src/routes/(customer)/+layout.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { page } from '$app/state';
   import CustomerLayout from '$lib/components/customer/layout/CustomerLayout.svelte';
+  import QueueWidget from '$lib/components/customer/queue/QueueWidget.svelte';
+  import { queueStore } from '$lib/stores/queue.svelte';
   import type { Snippet } from 'svelte';
 
   interface Props {
@@ -11,8 +13,14 @@
   let user = $derived(page.data.user);
   let searchQuery = $derived(page.url.searchParams.get('q') ?? '');
   let categories = $derived(page.data.categories ?? []);
+
+  // Khởi tạo store một lần duy nhất ở đây — phục hồi từ localStorage
+  queueStore.init();
 </script>
 
 <CustomerLayout {user} {searchQuery} {categories}>
   {@render children()}
 </CustomerLayout>
+
+<!-- Floating Widget — luôn hiện bất kể ở trang nào trong customer layout -->
+<QueueWidget />

--- a/src/routes/(customer)/events/[id]/+page.svelte
+++ b/src/routes/(customer)/events/[id]/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { queueStore } from '$lib/stores/queue.svelte';
+  import CrossQueueModal from '$lib/components/customer/queue/CrossQueueModal.svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
@@ -38,6 +40,9 @@
   let earliestShow = $derived(visibleShows.length > 0 ? visibleShows[0] : null);
 
   let selectedShowId = $state<number | null>(null);
+  // Cross-queue modal state
+  let showCrossQueueModal = $state(false);
+  let pendingShowId = $state<number | null>(null);
   let activeShow = $derived<EventDetailShow | null>(
     visibleShows.length === 0
       ? null
@@ -109,12 +114,68 @@
     return 'border-t-primary';
   }
 
-  function handleBuyTicket(showId: number) {
+  async function joinQueue(showId: number) {
+    const seatsPath = resolve(`/events/${event.id}/shows/${showId}/seats`);
+    try {
+      const res = await fetch(`/api/events/${event.id}/queue`, { method: 'POST' });
+      const result = await res.json();
+
+      if (res.status === 403) {
+        // Server-side cross-queue guard (Redis Lua) đã chặn
+        // → Hiện CrossQueueModal để user chọn rời cũ hoặc ở lại
+        pendingShowId = showId;
+        showCrossQueueModal = true;
+        return;
+      }
+
+      if (!res.ok) {
+        alert(result.message || 'Có lỗi xảy ra khi tham gia hàng chờ.');
+        return;
+      }
+
+      queueStore.eventId = event.id;
+      queueStore.eventTitle = event.title;
+      queueStore.showId = showId;
+
+      if (result.data.status === 'waiting') {
+        queueStore.status = 'waiting';
+        queueStore.position = result.data.position;
+        goto(`/events/${event.id}/queue`);
+      } else if (result.data.status === 'active') {
+        queueStore.status = 'holding';
+        queueStore.expiresAt = result.data.expiresAt;
+        queueStore.token = result.data.token;
+        goto(seatsPath);
+      }
+    } catch (error) {
+      console.error('Lỗi khi join queue:', error);
+      alert('Không thể kết nối đến hệ thống hàng chờ.');
+    }
+  }
+
+  async function handleBuyTicket(showId: number) {
     const seatsPath = resolve(`/events/${event.id}/shows/${showId}/seats`);
     if (!user) {
       goto(resolve(`/login?redirect=${encodeURIComponent(seatsPath)}`));
-    } else {
-      goto(seatsPath);
+      return;
+    }
+
+    // Kiểm tra xung đột hàng chờ
+    if (queueStore.hasConflict(event.id)) {
+      pendingShowId = showId;
+      showCrossQueueModal = true;
+      return;
+    }
+
+    await joinQueue(showId);
+  }
+
+  async function handleLeaveAndJoin() {
+    showCrossQueueModal = false;
+    await queueStore.leaveForNewEvent();
+    if (pendingShowId) {
+      await joinQueue(pendingShowId);
+      pendingShowId = null;
     }
   }
 
@@ -621,3 +682,12 @@
     </div>
   {/if}
 </div>
+
+<!-- Cross-Queue Modal -->
+<CrossQueueModal
+  open={showCrossQueueModal}
+  currentEventTitle={queueStore.eventTitle}
+  newEventTitle={event.title}
+  onStay={() => (showCrossQueueModal = false)}
+  onLeaveAndJoin={handleLeaveAndJoin}
+/>

--- a/src/routes/(customer)/events/[id]/+page.svelte
+++ b/src/routes/(customer)/events/[id]/+page.svelte
@@ -13,6 +13,7 @@
   import type { SeatLayoutConfig } from '$lib/types/seat-map';
   import { formatDate, formatTime } from '$lib/utils/datetime';
   import { formatPrice } from '$lib/utils/price';
+  import { api } from '$lib/utils/api';
   import {
     ArrowRight,
     Building,
@@ -115,45 +116,42 @@
   }
 
   async function joinQueue(showId: number) {
-    // const seatsPath = resolve(`/events/${event.id}/shows/${showId}/seats`);
-    try {
-      const res = await fetch(`/api/events/${event.id}/queue`, { method: 'POST' });
-      const result = await res.json();
+    const result = await api.post<{
+      status: 'waiting' | 'active';
+      position?: number;
+      expiresAt?: number;
+      token?: string;
+    }>(`/events/${event.id}/queue`, {}, { silent: true });
 
-      if (res.status === 403) {
-        // Server-side cross-queue guard (Redis Lua) đã chặn
-        // → Hiện CrossQueueModal để user chọn rời cũ hoặc ở lại
-        pendingShowId = showId;
-        showCrossQueueModal = true;
-        return;
+    if (result.status === 403) {
+      // Server-side cross-queue guard (Redis Lua) blocked → show modal
+      pendingShowId = showId;
+      showCrossQueueModal = true;
+      return;
+    }
+
+    if (result.error || !result.data) {
+      // api util already showed a toast for non-silent errors
+      return;
+    }
+
+    queueStore.eventId = event.id;
+    queueStore.eventTitle = event.title;
+    queueStore.showId = showId;
+
+    if (result.data.status === 'waiting') {
+      queueStore.status = 'waiting';
+      queueStore.position = result.data.position ?? 0;
+      goto(resolve(`/events/${event.id}/queue`));
+    } else if (result.data.status === 'active') {
+      queueStore.status = 'ready';
+      queueStore.expiresAt = result.data.expiresAt ?? null;
+      if (result.data.token) {
+        queueStore.token = result.data.token;
       }
-
-      if (!res.ok) {
-        alert(result.message || 'Có lỗi xảy ra khi tham gia hàng chờ.');
-        return;
-      }
-
-      queueStore.eventId = event.id;
-      queueStore.eventTitle = event.title;
-      queueStore.showId = showId;
-
-      if (result.data?.status === 'waiting') {
-        queueStore.status = 'waiting';
-        queueStore.position = result.data.position;
-        goto(resolve(`/events/${event.id}/queue`));
-      } else if (result.data?.status === 'active') {
-        queueStore.status = 'ready';
-        queueStore.expiresAt = result.data.expiresAt;
-        if (result.data.token) {
-          queueStore.token = result.data.token;
-        }
-        goto(resolve(`/events/${event.id}/queue`));
-      } else {
-        alert('Hệ thống trả về trạng thái không xác định. Vui lòng thử lại!');
-      }
-    } catch (error) {
-      console.error('Lỗi khi join queue:', error);
-      alert('Không thể kết nối đến hệ thống hàng chờ.');
+      goto(resolve(`/events/${event.id}/queue`));
+    } else {
+      // api util will show error toast
     }
   }
 

--- a/src/routes/(customer)/events/[id]/+page.svelte
+++ b/src/routes/(customer)/events/[id]/+page.svelte
@@ -115,7 +115,7 @@
   }
 
   async function joinQueue(showId: number) {
-    const seatsPath = resolve(`/events/${event.id}/shows/${showId}/seats`);
+    // const seatsPath = resolve(`/events/${event.id}/shows/${showId}/seats`);
     try {
       const res = await fetch(`/api/events/${event.id}/queue`, { method: 'POST' });
       const result = await res.json();
@@ -171,6 +171,7 @@
         return;
       }
       if (queueStore.status === 'ready' || queueStore.status === 'waiting') {
+        queueStore.showId = showId;
         goto(resolve(`/events/${event.id}/queue`));
         return;
       }

--- a/src/routes/(customer)/events/[id]/+page.svelte
+++ b/src/routes/(customer)/events/[id]/+page.svelte
@@ -137,15 +137,19 @@
       queueStore.eventTitle = event.title;
       queueStore.showId = showId;
 
-      if (result.data.status === 'waiting') {
+      if (result.data?.status === 'waiting') {
         queueStore.status = 'waiting';
         queueStore.position = result.data.position;
-        goto(`/events/${event.id}/queue`);
-      } else if (result.data.status === 'active') {
-        queueStore.status = 'holding';
+        goto(resolve(`/events/${event.id}/queue`));
+      } else if (result.data?.status === 'active') {
+        queueStore.status = 'ready';
         queueStore.expiresAt = result.data.expiresAt;
-        queueStore.token = result.data.token;
-        goto(seatsPath);
+        if (result.data.token) {
+          queueStore.token = result.data.token;
+        }
+        goto(resolve(`/events/${event.id}/queue`));
+      } else {
+        alert('Hệ thống trả về trạng thái không xác định. Vui lòng thử lại!');
       }
     } catch (error) {
       console.error('Lỗi khi join queue:', error);
@@ -158,6 +162,18 @@
     if (!user) {
       goto(resolve(`/login?redirect=${encodeURIComponent(seatsPath)}`));
       return;
+    }
+
+    // Nếu user đang trong luồng của chính event này, dùng luôn trạng thái hiện tại
+    if (queueStore.eventId === event.id) {
+      if (queueStore.status === 'holding') {
+        goto(seatsPath);
+        return;
+      }
+      if (queueStore.status === 'ready' || queueStore.status === 'waiting') {
+        goto(resolve(`/events/${event.id}/queue`));
+        return;
+      }
     }
 
     // Kiểm tra xung đột hàng chờ

--- a/src/routes/(customer)/events/[id]/queue/+page.svelte
+++ b/src/routes/(customer)/events/[id]/queue/+page.svelte
@@ -4,6 +4,7 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { queueStore } from '$lib/stores/queue.svelte';
+  import { api } from '$lib/utils/api';
   import { onMount } from 'svelte';
   import { Clock, Loader2, Users } from 'lucide-svelte';
 
@@ -47,30 +48,30 @@
   );
 
   async function pollStatus() {
-    try {
-      const res = await fetch(`/api/events/${eventId}/queue/status`);
-      if (!res.ok) return;
-      const { data } = await res.json();
-      pollingError = false;
+    const result = await api.get<{
+      status: 'active' | 'waiting' | 'none';
+      position?: number;
+      expiresAt?: number;
+      token?: string;
+    }>(`/events/${eventId}/queue/status`, { silent: true });
 
-      if (data.status === 'active') {
-        // Server báo tới lượt → chuyển sang grace period
-        queueStore.status = 'ready';
-        queueStore.expiresAt = data.expiresAt;
-        // Server chỉ mint token mới khi ≤30s còn lại → không ghi đè token cũ nếu null
-        if (data.token) {
-          queueStore.token = data.token;
-        }
-      } else if (data.status === 'waiting') {
-        queueStore.status = 'waiting';
-        queueStore.position = data.position;
-      } else if (data.status === 'none') {
-        // Bị đuổi khỏi queue (timeout, worker eviction, ...)
-        queueStore.clear();
-        goto(resolve(`/events/${eventId}`));
-      }
-    } catch {
+    if (result.error || !result.data) {
       pollingError = true;
+      return;
+    }
+    pollingError = false;
+
+    const data = result.data;
+    if (data.status === 'active') {
+      queueStore.status = 'ready';
+      queueStore.expiresAt = data.expiresAt ?? null;
+      if (data.token) queueStore.token = data.token;
+    } else if (data.status === 'waiting') {
+      queueStore.status = 'waiting';
+      queueStore.position = data.position ?? queueStore.position;
+    } else if (data.status === 'none') {
+      queueStore.clear();
+      goto(resolve(`/events/${eventId}`));
     }
   }
 
@@ -78,16 +79,14 @@
     if (isConfirming) return;
     isConfirming = true;
     try {
-      const res = await fetch(`/api/events/${eventId}/queue/confirm`, { method: 'POST' });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        alert(err?.message ?? 'Không thể xác nhận. Vui lòng thử lại.');
-        return;
-      }
-      const { data } = await res.json();
-      // Lưu vào pendingConfirm thay vì set 'holding' ngay — tránh flash widget cam
-      // seats/+page.svelte sẽ gọi queueStore.commitHolding() khi mount
-      queueStore.setPendingConfirm(data.expiresAt, data.token);
+      const result = await api.post<{ expiresAt: number; token: string }>(
+        `/events/${eventId}/queue/confirm`,
+        {}
+      );
+
+      if (result.error || !result.data) return; // toast shown by api util
+
+      queueStore.setPendingConfirm(result.data.expiresAt, result.data.token);
 
       const showId = queueStore.showId;
       if (showId) {
@@ -95,8 +94,6 @@
       } else {
         goto(resolve(`/events/${eventId}`));
       }
-    } catch {
-      alert('Có lỗi xảy ra. Vui lòng thử lại.');
     } finally {
       isConfirming = false;
     }

--- a/src/routes/(customer)/events/[id]/queue/+page.svelte
+++ b/src/routes/(customer)/events/[id]/queue/+page.svelte
@@ -115,56 +115,58 @@
   <title>Phòng chờ ảo — {queueStore.eventTitle || 'TixTac'}</title>
 </svelte:head>
 
-<div class="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center bg-surface p-4">
-  <div class="w-full max-w-md">
+<div class="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center bg-surface sm:p-4">
+  <div class="w-full flex-1 sm:max-w-md sm:flex-none flex flex-col justify-between sm:justify-start">
     <!-- ═══════════════════════════════════════════ -->
     <!-- TRẠNG THÁI: WAITING                         -->
     <!-- ═══════════════════════════════════════════ -->
     {#if queueStore.status === 'waiting'}
       <div
-        class="overflow-hidden rounded-2xl bg-surface-container shadow-2xl ring-1 ring-outline-variant/20"
+        class="flex flex-1 flex-col sm:block sm:overflow-hidden sm:rounded-2xl sm:bg-surface-container sm:shadow-2xl sm:ring-1 sm:ring-outline-variant/20"
       >
         <!-- Top gradient accent -->
-        <div class="h-1.5 bg-gradient-to-r from-primary via-primary/70 to-transparent"></div>
+        <div class="h-1.5 bg-gradient-to-r from-primary via-primary/70 to-transparent hidden sm:block"></div>
 
-        <div class="p-8">
-          <!-- Illustration -->
-          <div class="mb-6 flex justify-center">
-            <div class="relative flex h-24 w-24 items-center justify-center">
-              <!-- Pulse rings -->
-              <div class="absolute h-24 w-24 animate-ping rounded-full bg-primary/10"></div>
-              <div
-                class="absolute h-16 w-16 animate-ping rounded-full bg-primary/15 [animation-delay:300ms]"
-              ></div>
-              <div
-                class="relative flex h-12 w-12 items-center justify-center rounded-full bg-primary/20"
-              >
-                <Loader2 class="h-6 w-6 animate-spin text-primary" />
+        <div class="flex flex-1 flex-col p-6 sm:p-8">
+          
+          <div class="flex-1 flex flex-col items-center justify-center pt-8 sm:pt-0">
+            <!-- Illustration -->
+            <div class="mb-8 flex justify-center">
+              <div class="relative flex h-24 w-24 items-center justify-center">
+                <!-- Pulse rings -->
+                <div class="absolute h-24 w-24 animate-ping rounded-full bg-primary/10"></div>
+                <div
+                  class="absolute h-16 w-16 animate-ping rounded-full bg-primary/15 [animation-delay:300ms]"
+                ></div>
+                <div
+                  class="relative flex h-12 w-12 items-center justify-center rounded-full bg-primary/20"
+                >
+                  <Loader2 class="h-6 w-6 animate-spin text-primary" />
+                </div>
               </div>
             </div>
-          </div>
 
-          <h1 class="mb-2 text-center font-heading text-2xl font-black text-foreground">
-            Đang xếp hàng
-          </h1>
-          {#if queueStore.eventTitle}
-            <p class="mb-6 text-center text-sm font-medium text-primary">{queueStore.eventTitle}</p>
-          {:else}
-            <p class="mb-6 text-center text-sm text-muted-foreground">
-              Vui lòng không tắt trình duyệt
-            </p>
-          {/if}
+            <h1 class="mb-2 text-center font-heading text-2xl font-black text-foreground">
+              Đang xếp hàng
+            </h1>
+            {#if queueStore.eventTitle}
+              <p class="mb-8 text-center text-sm font-medium text-primary">{queueStore.eventTitle}</p>
+            {:else}
+              <p class="mb-8 text-center text-sm text-muted-foreground">
+                Vui lòng không tắt trình duyệt
+              </p>
+            {/if}
 
-          <!-- Position display -->
-          <div
-            class="mb-6 rounded-2xl bg-surface-container-low p-6 text-center ring-1 ring-outline-variant/30"
-          >
-            <p class="mb-1 text-[10px] font-bold tracking-widest text-muted-foreground uppercase">
-              Vị trí của bạn
-            </p>
-            <div class="font-mono text-7xl font-black text-primary">
-              #{queueStore.position}
-            </div>
+            <!-- Position display -->
+            <div
+              class="mb-6 w-full rounded-2xl bg-surface-container-low sm:bg-surface p-6 text-center sm:ring-1 ring-outline-variant/30 shadow-inner sm:shadow-none"
+            >
+              <p class="mb-2 text-xs font-bold tracking-widest text-muted-foreground uppercase">
+                Vị trí của bạn
+              </p>
+              <div class="font-mono text-7xl font-black text-primary px-2">
+                #{queueStore.position}
+              </div>
             {#if estimatedWait}
               <div
                 class="mt-3 flex items-center justify-center gap-1.5 text-sm text-muted-foreground"
@@ -186,29 +188,29 @@
             </p>
           {/if}
 
-          <!-- Info note -->
-          <div class="mb-6 flex items-start gap-2 rounded-xl bg-primary/5 p-3">
-            <Users class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-            <p class="text-xs leading-relaxed text-muted-foreground">
-              Hệ thống sẽ tự động thông báo khi tới lượt bạn. Bạn có thể thu nhỏ phòng chờ và lướt
-              web trong khi chờ.
-            </p>
+            <!-- Info note -->
+            <div class="flex items-start gap-2 rounded-xl bg-primary/5 p-4">
+              <Users class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+              <p class="text-xs leading-relaxed text-muted-foreground">
+                Hệ thống tự động thông báo khi tới lượt. Bạn có thể thu nhỏ phòng chờ và lướt web.
+              </p>
+            </div>
           </div>
 
-          <!-- Action buttons -->
-          <div class="flex flex-col gap-3">
+          <!-- Bottom Actions (Sticky on Mobile) -->
+          <div class="mt-8 flex flex-col gap-4 sticky bottom-0 bg-surface sm:bg-transparent pb-4 pt-2 sm:p-0">
             <button
               onclick={() => {
                 queueStore.isMinimized = true;
                 goto(`/events/${eventId}`);
               }}
-              class="w-full rounded-xl bg-surface-container-highest px-6 py-3.5 font-bold text-foreground transition-all hover:bg-surface-container-high active:scale-95"
+              class="w-full rounded-full sm:rounded-xl bg-surface-container-highest sm:bg-surface-container-high px-6 py-4 font-bold text-foreground shadow-lg sm:shadow-none transition-all hover:bg-surface-container-highest active:scale-95"
             >
               Thu nhỏ & Xem thông tin sự kiện
             </button>
             <button
               onclick={() => queueStore.leave()}
-              class="text-sm font-medium text-muted-foreground transition hover:text-destructive"
+              class="py-2 text-sm font-medium text-muted-foreground transition hover:text-destructive"
             >
               Hủy xếp hàng
             </button>
@@ -221,20 +223,22 @@
       <!-- ═══════════════════════════════════════════ -->
     {:else if queueStore.status === 'ready'}
       <div
-        class="relative overflow-hidden rounded-2xl bg-gradient-to-b from-emerald-600 to-emerald-700 p-8 text-white shadow-2xl shadow-emerald-900/40"
+        class="flex flex-1 flex-col justify-center relative sm:overflow-hidden sm:rounded-2xl bg-gradient-to-b from-emerald-500 to-emerald-700 sm:from-emerald-600 sm:to-emerald-700 p-6 sm:p-8 text-white sm:shadow-2xl sm:shadow-emerald-900/40"
       >
         <!-- Background decoration -->
-        <div class="absolute -top-12 -right-12 h-48 w-48 rounded-full bg-white/5"></div>
-        <div class="absolute -bottom-8 -left-8 h-32 w-32 rounded-full bg-white/5"></div>
+        <div class="absolute -top-12 -right-12 h-64 w-64 rounded-full bg-white/10 blur-2xl"></div>
+        <div class="absolute -bottom-12 -left-12 h-64 w-64 rounded-full bg-white/10 blur-2xl"></div>
 
-        <div class="relative">
-          <!-- Checkmark icon -->
-          <div class="mb-6 flex justify-center">
-            <div
-              class="flex h-20 w-20 items-center justify-center rounded-full bg-white/20 ring-8 ring-white/10"
-            >
-              <svg
-                class="h-10 w-10"
+        <div class="relative flex flex-col flex-1 justify-between sm:justify-center">
+          
+          <div class="flex-1 flex flex-col justify-center">
+            <!-- Checkmark icon -->
+            <div class="mb-8 flex justify-center">
+              <div
+                class="flex h-24 w-24 items-center justify-center rounded-full bg-white/20 ring-8 ring-white/10"
+              >
+                <svg
+                  class="h-12 w-12"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -245,22 +249,22 @@
             </div>
           </div>
 
-          <h1 class="mb-2 text-center font-heading text-3xl font-black">ĐÃ TỚI LƯỢT!</h1>
-          {#if queueStore.eventTitle}
-            <p class="mb-6 text-center text-sm font-medium opacity-80">{queueStore.eventTitle}</p>
-          {:else}
-            <p class="mb-6 text-center text-sm opacity-80">
-              Bạn có 1 phút để vào chọn ghế trước khi hệ thống nhường chỗ cho người tiếp theo.
-            </p>
-          {/if}
+            <h1 class="mb-2 text-center font-heading text-4xl sm:text-3xl font-black">ĐÃ TỚI LƯỢT!</h1>
+            {#if queueStore.eventTitle}
+              <p class="mb-8 text-center text-base sm:text-sm font-medium opacity-90">{queueStore.eventTitle}</p>
+            {:else}
+              <p class="mb-8 text-center text-sm opacity-90">
+                Bạn có 1 phút để vào chọn ghế trước khi hệ thống nhường chỗ.
+              </p>
+            {/if}
 
-          <!-- Countdown ring -->
-          <div class="mb-6 text-center">
-            <p class="text-sm opacity-70">Xác nhận trong vòng</p>
-            <p class="font-mono text-6xl leading-none font-black tabular-nums">
-              {formatTime(timeLeft)}
-            </p>
-            <p class="mt-1 text-xs opacity-60">giây</p>
+            <!-- Countdown ring -->
+            <div class="mb-8 rounded-3xl bg-black/10 py-6 text-center backdrop-blur-sm sm:bg-transparent sm:py-0 sm:backdrop-blur-none">
+              <p class="text-sm opacity-80 uppercase tracking-widest font-bold mb-2">Xác nhận trong vòng</p>
+              <p class="font-mono text-7xl sm:text-6xl leading-none font-black tabular-nums">
+                {formatTime(timeLeft)}
+              </p>
+            </div>
           </div>
 
           <!-- Progress bar -->
@@ -271,15 +275,17 @@
             ></div>
           </div>
 
-          <button
-            onclick={handleConfirm}
-            disabled={isConfirming}
-            class="w-full animate-pulse rounded-xl bg-white px-8 py-4 text-lg font-black text-emerald-700
-                   shadow-xl shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95
-                   disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {isConfirming ? 'Đang xử lý...' : 'VÀO CHỌN GHẾ NGAY →'}
-          </button>
+          <div class="mt-4 pb-4 sm:pb-0">
+            <button
+              onclick={handleConfirm}
+              disabled={isConfirming}
+              class="w-full animate-pulse rounded-full sm:rounded-xl bg-white px-6 py-4 text-lg font-black text-emerald-700
+                     shadow-[0_8px_30px_rgb(0,0,0,0.2)] sm:shadow-xl sm:shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95
+                     disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isConfirming ? 'Đang xử lý...' : 'VÀO CHỌN GHẾ NGAY →'}
+            </button>
+          </div>
         </div>
       </div>
     {/if}

--- a/src/routes/(customer)/events/[id]/queue/+page.svelte
+++ b/src/routes/(customer)/events/[id]/queue/+page.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { queueStore } from '$lib/stores/queue.svelte';
   import { onMount } from 'svelte';
   import { Clock, Loader2, Users } from 'lucide-svelte';
@@ -66,7 +67,7 @@
       } else if (data.status === 'none') {
         // Bị đuổi khỏi queue (timeout, worker eviction, ...)
         queueStore.clear();
-        goto(`/events/${eventId}`);
+        goto(resolve(`/events/${eventId}`));
       }
     } catch {
       pollingError = true;
@@ -90,9 +91,9 @@
 
       const showId = queueStore.showId;
       if (showId) {
-        goto(`/events/${eventId}/shows/${showId}/seats`);
+        goto(resolve(`/events/${eventId}/shows/${showId}/seats`));
       } else {
-        goto(`/events/${eventId}`);
+        goto(resolve(`/events/${eventId}`));
       }
     } catch {
       alert('Có lỗi xảy ra. Vui lòng thử lại.');
@@ -103,10 +104,15 @@
 
   onMount(() => {
     // Nếu store đã ready (F5 trong grace period), không cần poll lại ngay
-    if (queueStore.status !== 'ready') {
+    if (queueStore.status !== 'ready') pollStatus();
+    
+    const interval = setInterval(() => {
+      // Stop polling once the server has promoted us; the countdown owns the
+      // expiresAt from here on, and the /confirm flow drives the next state.
+      if (queueStore.status === 'ready' || queueStore.status === 'holding') return;
       pollStatus();
-    }
-    const interval = setInterval(pollStatus, 5000);
+    }, 5000);
+    
     return () => clearInterval(interval);
   });
 </script>
@@ -128,7 +134,7 @@
         <div class="h-1.5 bg-gradient-to-r from-primary via-primary/70 to-transparent hidden sm:block"></div>
 
         <div class="flex flex-1 flex-col p-6 sm:p-8">
-          
+
           <div class="flex-1 flex flex-col items-center justify-center pt-8 sm:pt-0">
             <!-- Illustration -->
             <div class="mb-8 flex justify-center">
@@ -197,14 +203,14 @@
             </div>
           </div>
 
-          <!-- Bottom Actions (Sticky on Mobile) -->
-          <div class="mt-8 flex flex-col gap-4 sticky bottom-0 bg-surface sm:bg-transparent pb-4 pt-2 sm:p-0">
+          <!-- Bottom Actions -->
+          <div class="mt-auto flex flex-col gap-4 pb-12 pt-8 sm:pb-0">
             <button
               onclick={() => {
                 queueStore.isMinimized = true;
-                goto(`/events/${eventId}`);
+                goto(resolve(`/events/${eventId}`));
               }}
-              class="w-full rounded-full sm:rounded-xl bg-surface-container-highest sm:bg-surface-container-high px-6 py-4 font-bold text-foreground shadow-lg sm:shadow-none transition-all hover:bg-surface-container-highest active:scale-95"
+              class="w-full rounded-xl bg-surface-container-highest sm:bg-surface-container-high px-6 py-4 font-bold text-foreground shadow-lg sm:shadow-none transition-all hover:bg-surface-container-highest active:scale-95"
             >
               Thu nhỏ & Xem thông tin sự kiện
             </button>
@@ -230,7 +236,7 @@
         <div class="absolute -bottom-12 -left-12 h-64 w-64 rounded-full bg-white/10 blur-2xl"></div>
 
         <div class="relative flex flex-col flex-1 justify-between sm:justify-center">
-          
+
           <div class="flex-1 flex flex-col justify-center">
             <!-- Checkmark icon -->
             <div class="mb-8 flex justify-center">
@@ -275,11 +281,11 @@
             ></div>
           </div>
 
-          <div class="mt-4 pb-4 sm:pb-0">
+          <div class="mt-auto pt-8 pb-12 sm:pb-0">
             <button
               onclick={handleConfirm}
               disabled={isConfirming}
-              class="w-full animate-pulse rounded-full sm:rounded-xl bg-white px-6 py-4 text-lg font-black text-emerald-700
+              class="w-full animate-pulse rounded-xl bg-white px-6 py-4 text-lg font-black text-emerald-700
                      shadow-[0_8px_30px_rgb(0,0,0,0.2)] sm:shadow-xl sm:shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95
                      disabled:cursor-not-allowed disabled:opacity-70"
             >

--- a/src/routes/(customer)/events/[id]/queue/+page.svelte
+++ b/src/routes/(customer)/events/[id]/queue/+page.svelte
@@ -195,7 +195,7 @@
           {/if}
 
             <!-- Info note -->
-            <div class="flex items-start gap-2 rounded-xl bg-primary/5 p-4">
+            <div class="w-full flex items-start gap-3 rounded-2xl bg-primary/5 p-6">
               <Users class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
               <p class="text-xs leading-relaxed text-muted-foreground">
                 Hệ thống tự động thông báo khi tới lượt. Bạn có thể thu nhỏ phòng chờ và lướt web.

--- a/src/routes/(customer)/events/[id]/queue/+page.svelte
+++ b/src/routes/(customer)/events/[id]/queue/+page.svelte
@@ -1,0 +1,287 @@
+<!-- src/routes/(customer)/events/[id]/queue/+page.svelte -->
+<script lang="ts">
+  import { page } from '$app/state';
+  import { goto } from '$app/navigation';
+  import { queueStore } from '$lib/stores/queue.svelte';
+  import { onMount } from 'svelte';
+  import { Clock, Loader2, Users } from 'lucide-svelte';
+
+  let eventId = $derived(Number(page.params.id));
+
+  let isConfirming = $state(false);
+  let pollingError = $state(false);
+
+  // Countdown cho grace period (chỉ dùng khi status === 'ready')
+  let timeLeft = $state(0);
+  $effect(() => {
+    if (queueStore.status !== 'ready' || !queueStore.expiresAt) {
+      timeLeft = 0;
+      return;
+    }
+    const update = () => {
+      timeLeft = Math.max(0, Math.floor((queueStore.expiresAt! - Date.now()) / 1000));
+      if (timeLeft === 0) {
+        queueStore.status = 'missed';
+        queueStore.leave();
+      }
+    };
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  });
+
+  function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  // Thời gian chờ ước tính: mỗi người ~30 giây
+  let estimatedWait = $derived(
+    queueStore.position > 0
+      ? queueStore.position <= 2
+        ? 'Sắp tới lượt!'
+        : `~${Math.ceil((queueStore.position * 30) / 60)} phút`
+      : '',
+  );
+
+  async function pollStatus() {
+    try {
+      const res = await fetch(`/api/events/${eventId}/queue/status`);
+      if (!res.ok) return;
+      const { data } = await res.json();
+      pollingError = false;
+
+      if (data.status === 'active') {
+        // Server báo tới lượt → chuyển sang grace period
+        queueStore.status = 'ready';
+        queueStore.expiresAt = data.expiresAt;
+        // Server chỉ mint token mới khi ≤30s còn lại → không ghi đè token cũ nếu null
+        if (data.token) {
+          queueStore.token = data.token;
+        }
+      } else if (data.status === 'waiting') {
+        queueStore.status = 'waiting';
+        queueStore.position = data.position;
+      } else if (data.status === 'none') {
+        // Bị đuổi khỏi queue (timeout, worker eviction, ...)
+        queueStore.clear();
+        goto(`/events/${eventId}`);
+      }
+    } catch {
+      pollingError = true;
+    }
+  }
+
+  async function handleConfirm() {
+    if (isConfirming) return;
+    isConfirming = true;
+    try {
+      const res = await fetch(`/api/events/${eventId}/queue/confirm`, { method: 'POST' });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(err?.message ?? 'Không thể xác nhận. Vui lòng thử lại.');
+        return;
+      }
+      const { data } = await res.json();
+      // Lưu vào pendingConfirm thay vì set 'holding' ngay — tránh flash widget cam
+      // seats/+page.svelte sẽ gọi queueStore.commitHolding() khi mount
+      queueStore.setPendingConfirm(data.expiresAt, data.token);
+
+      const showId = queueStore.showId;
+      if (showId) {
+        goto(`/events/${eventId}/shows/${showId}/seats`);
+      } else {
+        goto(`/events/${eventId}`);
+      }
+    } catch {
+      alert('Có lỗi xảy ra. Vui lòng thử lại.');
+    } finally {
+      isConfirming = false;
+    }
+  }
+
+  onMount(() => {
+    // Nếu store đã ready (F5 trong grace period), không cần poll lại ngay
+    if (queueStore.status !== 'ready') {
+      pollStatus();
+    }
+    const interval = setInterval(pollStatus, 5000);
+    return () => clearInterval(interval);
+  });
+</script>
+
+<svelte:head>
+  <title>Phòng chờ ảo — {queueStore.eventTitle || 'TixTac'}</title>
+</svelte:head>
+
+<div class="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center bg-surface p-4">
+  <div class="w-full max-w-md">
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- TRẠNG THÁI: WAITING                         -->
+    <!-- ═══════════════════════════════════════════ -->
+    {#if queueStore.status === 'waiting'}
+      <div
+        class="overflow-hidden rounded-2xl bg-surface-container shadow-2xl ring-1 ring-outline-variant/20"
+      >
+        <!-- Top gradient accent -->
+        <div class="h-1.5 bg-gradient-to-r from-primary via-primary/70 to-transparent"></div>
+
+        <div class="p-8">
+          <!-- Illustration -->
+          <div class="mb-6 flex justify-center">
+            <div class="relative flex h-24 w-24 items-center justify-center">
+              <!-- Pulse rings -->
+              <div class="absolute h-24 w-24 animate-ping rounded-full bg-primary/10"></div>
+              <div
+                class="absolute h-16 w-16 animate-ping rounded-full bg-primary/15 [animation-delay:300ms]"
+              ></div>
+              <div
+                class="relative flex h-12 w-12 items-center justify-center rounded-full bg-primary/20"
+              >
+                <Loader2 class="h-6 w-6 animate-spin text-primary" />
+              </div>
+            </div>
+          </div>
+
+          <h1 class="mb-2 text-center font-heading text-2xl font-black text-foreground">
+            Đang xếp hàng
+          </h1>
+          {#if queueStore.eventTitle}
+            <p class="mb-6 text-center text-sm font-medium text-primary">{queueStore.eventTitle}</p>
+          {:else}
+            <p class="mb-6 text-center text-sm text-muted-foreground">
+              Vui lòng không tắt trình duyệt
+            </p>
+          {/if}
+
+          <!-- Position display -->
+          <div
+            class="mb-6 rounded-2xl bg-surface-container-low p-6 text-center ring-1 ring-outline-variant/30"
+          >
+            <p class="mb-1 text-[10px] font-bold tracking-widest text-muted-foreground uppercase">
+              Vị trí của bạn
+            </p>
+            <div class="font-mono text-7xl font-black text-primary">
+              #{queueStore.position}
+            </div>
+            {#if estimatedWait}
+              <div
+                class="mt-3 flex items-center justify-center gap-1.5 text-sm text-muted-foreground"
+              >
+                <Clock class="h-4 w-4" />
+                <span>
+                  Thời gian chờ ước tính: <strong class="text-foreground">{estimatedWait}</strong>
+                </span>
+              </div>
+            {/if}
+          </div>
+
+          <!-- Connection error -->
+          {#if pollingError}
+            <p
+              class="mb-4 rounded-lg bg-destructive/10 px-3 py-2 text-center text-xs text-destructive"
+            >
+              Mất kết nối. Đang thử lại...
+            </p>
+          {/if}
+
+          <!-- Info note -->
+          <div class="mb-6 flex items-start gap-2 rounded-xl bg-primary/5 p-3">
+            <Users class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <p class="text-xs leading-relaxed text-muted-foreground">
+              Hệ thống sẽ tự động thông báo khi tới lượt bạn. Bạn có thể thu nhỏ phòng chờ và lướt
+              web trong khi chờ.
+            </p>
+          </div>
+
+          <!-- Action buttons -->
+          <div class="flex flex-col gap-3">
+            <button
+              onclick={() => {
+                queueStore.isMinimized = true;
+                goto(`/events/${eventId}`);
+              }}
+              class="w-full rounded-xl bg-surface-container-highest px-6 py-3.5 font-bold text-foreground transition-all hover:bg-surface-container-high active:scale-95"
+            >
+              Thu nhỏ & Xem thông tin sự kiện
+            </button>
+            <button
+              onclick={() => queueStore.leave()}
+              class="text-sm font-medium text-muted-foreground transition hover:text-destructive"
+            >
+              Hủy xếp hàng
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══════════════════════════════════════════ -->
+      <!-- TRẠNG THÁI: READY (Grace Period 60s)        -->
+      <!-- ═══════════════════════════════════════════ -->
+    {:else if queueStore.status === 'ready'}
+      <div
+        class="relative overflow-hidden rounded-2xl bg-gradient-to-b from-emerald-600 to-emerald-700 p-8 text-white shadow-2xl shadow-emerald-900/40"
+      >
+        <!-- Background decoration -->
+        <div class="absolute -top-12 -right-12 h-48 w-48 rounded-full bg-white/5"></div>
+        <div class="absolute -bottom-8 -left-8 h-32 w-32 rounded-full bg-white/5"></div>
+
+        <div class="relative">
+          <!-- Checkmark icon -->
+          <div class="mb-6 flex justify-center">
+            <div
+              class="flex h-20 w-20 items-center justify-center rounded-full bg-white/20 ring-8 ring-white/10"
+            >
+              <svg
+                class="h-10 w-10"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="3"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+          </div>
+
+          <h1 class="mb-2 text-center font-heading text-3xl font-black">ĐÃ TỚI LƯỢT!</h1>
+          {#if queueStore.eventTitle}
+            <p class="mb-6 text-center text-sm font-medium opacity-80">{queueStore.eventTitle}</p>
+          {:else}
+            <p class="mb-6 text-center text-sm opacity-80">
+              Bạn có 1 phút để vào chọn ghế trước khi hệ thống nhường chỗ cho người tiếp theo.
+            </p>
+          {/if}
+
+          <!-- Countdown ring -->
+          <div class="mb-6 text-center">
+            <p class="text-sm opacity-70">Xác nhận trong vòng</p>
+            <p class="font-mono text-6xl leading-none font-black tabular-nums">
+              {formatTime(timeLeft)}
+            </p>
+            <p class="mt-1 text-xs opacity-60">giây</p>
+          </div>
+
+          <!-- Progress bar -->
+          <div class="mb-6 h-1.5 overflow-hidden rounded-full bg-white/20">
+            <div
+              class="h-full rounded-full bg-white transition-all duration-1000"
+              style="width: {Math.min(100, (timeLeft / 60) * 100)}%"
+            ></div>
+          </div>
+
+          <button
+            onclick={handleConfirm}
+            disabled={isConfirming}
+            class="w-full animate-pulse rounded-xl bg-white px-8 py-4 text-lg font-black text-emerald-700
+                   shadow-xl shadow-black/20 transition-all hover:animate-none hover:bg-white/90 active:scale-95
+                   disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isConfirming ? 'Đang xử lý...' : 'VÀO CHỌN GHẾ NGAY →'}
+          </button>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
@@ -74,6 +74,36 @@
     queueStore.commitHolding();
   });
 
+  // ── Countdown Timer cho phiên giữ chỗ ──
+  let timeLeft = $state<number | null>(null);
+
+  $effect(() => {
+    if (!queueStore.expiresAt || queueStore.status !== 'holding') {
+      timeLeft = null;
+      return;
+    }
+
+    const update = () => {
+      const remaining = Math.max(0, Math.floor((queueStore.expiresAt! - Date.now()) / 1000));
+      timeLeft = remaining;
+      if (remaining === 0) {
+        queueStore.status = 'missed';
+        queueStore.leave();
+      }
+    };
+
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  });
+
+  function formatCountdown(seconds: number | null): string {
+    if (seconds === null) return '--:--';
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
   // Sync from server data whenever the route's event/show changes
   // (handles initial load AND SvelteKit reusing this page for a different route)
   $effect(() => {
@@ -429,6 +459,17 @@
           Suất: {showTitle}
         </p>
       </div>
+
+      <!-- Đếm ngược phiên chọn ghế -->
+      {#if timeLeft !== null}
+        <div class="flex items-center gap-2 rounded-xl border border-orange-600/40 bg-orange-400/10 px-3 py-1.5 text-orange-700 sm:px-4 sm:py-2">
+          <Clock class="h-4 w-4 shrink-0 sm:h-5 sm:w-5" />
+          <div class="text-right">
+            <p class="text-[9px] font-bold tracking-widest uppercase opacity-80 sm:text-[10px]">Thời gian</p>
+            <p class="font-mono text-sm font-black tabular-nums leading-none sm:text-base">{formatCountdown(timeLeft)}</p>
+          </div>
+        </div>
+      {/if}
     </div>
   </header>
 

--- a/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
+++ b/src/routes/(customer)/events/[id]/shows/[showId]/seats/+page.svelte
@@ -6,6 +6,7 @@
   import SeatMap from '$lib/components/seat-map/SeatMap.svelte';
   import SummaryBar from '$lib/components/seat-map/SummaryBar.svelte';
   import { createSeatSelectionStore } from '$lib/stores/cart-store.svelte';
+  import { queueStore } from '$lib/stores/queue.svelte';
   import { toast } from '$lib/stores/toast';
   import type { ShowSummary } from '$lib/types/event-detail';
   import type { PendingOrder } from '$lib/types/purchase';
@@ -13,7 +14,8 @@
   import { api } from '$lib/utils/api';
   import { formatDate, formatShortDate, formatTime, getDayInTZ } from '$lib/utils/datetime';
   import { ArrowLeft, Calendar, ChevronDown, Clock, LoaderCircle } from 'lucide-svelte';
-  import { onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
+
   import { fly } from 'svelte/transition';
 
   interface PageData {
@@ -64,6 +66,12 @@
 
   $effect(() => {
     store.updateLimits(data.event.max_tickets_per_user, data.event.bought_count);
+  });
+
+  // Commit trạng thái holding ngay khi trang /seats mount
+  // Được gọi sau khi navigate từ /queue — tránh flash widget cam
+  onMount(() => {
+    queueStore.commitHolding();
   });
 
   // Sync from server data whenever the route's event/show changes
@@ -324,9 +332,10 @@
     });
 
     if (res.status === 201 && res.data) {
-      // Success: Clear cart and redirect
+      // Success: Clear cart + queue state, then redirect
       const orderId = res.data.order_id;
       store.clearAll();
+      queueStore.clear(); // Xóa trạng thái holding — Widget không hiện nữa
       goto(resolve(`/orders/${orderId}/checkout`));
       return;
     }

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,7 +1,26 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { verifyAuthToken } from '$lib/server/auth/jwt';
+import { redis } from '$lib/server/redis';
+import { queueService } from '$lib/server/services/queue.service';
 
 export const POST: RequestHandler = async ({ cookies }) => {
+  const token = cookies.get('auth_token');
+  if (token) {
+    try {
+      const payload = await verifyAuthToken(token);
+      const userId = Number(payload.sub);
+
+      // Look up any active queue slot for this user and release it immediately.
+      const eventId = await redis.get(`user_current_queue:${userId}`);
+      if (eventId) {
+        await queueService.leaveQueue(userId, Number(eventId));
+      }
+    } catch (err) {
+      console.warn('[Logout] Failed to clean up queue:', err);
+    }
+  }
+
   cookies.delete('auth_token', { path: '/' });
   return json({ data: { message: 'Đăng xuất thành công' } }, { status: 200 });
 };

--- a/src/routes/api/events/[id]/checkout/+server.ts
+++ b/src/routes/api/events/[id]/checkout/+server.ts
@@ -1,4 +1,3 @@
-// src/routes/api/events/[id]/checkout/+server.ts
 import { requireCustomer } from '$lib/server/auth/guards';
 import { apiHandler } from '$lib/server/handler';
 import { purchaseService } from '$lib/server/services/purchase.service';
@@ -23,5 +22,6 @@ export const POST = apiHandler(async ({ params, request, locals }) => {
 
   // 4. Gọi service (apiHandler handles AppError serialization + unknown-error logging)
   const result = await purchaseService.purchaseTickets(customerId, eventId, body, idempotencyKey);
+
   return json({ data: result }, { status: 201 });
 });

--- a/src/routes/api/events/[id]/queue/+server.ts
+++ b/src/routes/api/events/[id]/queue/+server.ts
@@ -17,7 +17,7 @@ export const POST = apiHandler(async ({ params, locals }) => {
   return json({ data: result }, { status: result.status === 'waiting' ? 202 : 200 });
 });
 
-// DELETE: Hủy/Rời hàng chờ
+/** DELETE /api/events/:id/queue — Leaves (cancels) the current queue slot for the authenticated user. */
 export const DELETE = apiHandler(async ({ params, locals }) => {
   const user = requireCustomer(locals);
 

--- a/src/routes/api/orders/[id]/checkout/+server.ts
+++ b/src/routes/api/orders/[id]/checkout/+server.ts
@@ -20,17 +20,18 @@ export const POST = apiHandler(async ({ params, locals }) => {
 
   // On successful payment, immediately release the queue slot so the next
   // waiting user can be promoted. The eventId is resolved from the first order item.
-  try {
-    const orderDetails = await orderService.getOrderDetails(orderId, customer.id);
-    const eventId = orderDetails.items[0]?.event.id;
-    if (eventId) {
-      void queueService
-        .leaveQueue(customer.id, eventId)
-        .catch((err) => console.error('[order_checkout] leaveQueue failed (non-critical):', err));
+  // This is run in a fire-and-forget block to avoid blocking the fast checkout response.
+  (async () => {
+    try {
+      const orderDetails = await orderService.getOrderDetails(orderId, customer.id);
+      const eventId = orderDetails.items[0]?.event.id;
+      if (eventId) {
+        await queueService.leaveQueue(customer.id, eventId);
+      }
+    } catch (err) {
+      console.error('[order_checkout] Failed to cleanup queue slot (non-critical):', err);
     }
-  } catch (err) {
-    console.error('[order_checkout] Failed to fetch orderDetails for queue release:', err);
-  }
+  })();
 
   return json({ data }, { status: 200 });
 });

--- a/src/routes/api/orders/[id]/checkout/+server.ts
+++ b/src/routes/api/orders/[id]/checkout/+server.ts
@@ -1,8 +1,8 @@
-// src/routes/api/orders/[id]/checkout/+server.ts
 import { requireCustomer } from '$lib/server/auth/guards';
 import { Errors, throwError } from '$lib/server/errors';
 import { apiHandler } from '$lib/server/handler';
 import { orderService } from '$lib/server/services/order.service';
+import { queueService } from '$lib/server/services/queue.service';
 import { json, redirect } from '@sveltejs/kit';
 
 export const POST = apiHandler(async ({ params, locals }) => {
@@ -17,6 +17,20 @@ export const POST = apiHandler(async ({ params, locals }) => {
   }
 
   const data = await orderService.checkout(orderId, customer.id);
+
+  // On successful payment, immediately release the queue slot so the next
+  // waiting user can be promoted. The eventId is resolved from the first order item.
+  try {
+    const orderDetails = await orderService.getOrderDetails(orderId, customer.id);
+    const eventId = orderDetails.items[0]?.event.id;
+    if (eventId) {
+      void queueService
+        .leaveQueue(customer.id, eventId)
+        .catch((err) => console.error('[order_checkout] leaveQueue failed (non-critical):', err));
+    }
+  } catch (err) {
+    console.error('[order_checkout] Failed to fetch orderDetails for queue release:', err);
+  }
 
   return json({ data }, { status: 200 });
 });


### PR DESCRIPTION
## Mô tả

Triển khai giao diện tương tác và luồng người dùng cho hệ thống Hàng chờ ảo (Virtual Queue). Đảm bảo trải nghiệm liền mạch từ khi bắt đầu xếp hàng cho đến khi chọn ghế, đồng thời cho phép người dùng tiếp tục lướt web thông qua widget nổi.

See #105 

## Loại thay đổi

- [x] 💄 UI / Style


## Screenshots / Demo

### **Phòng chờ & Polling:** Hiển thị đúng số thứ tự, tính năng "Thu nhỏ" hoạt động mượt mà

<img width="1920" height="2342" alt="image" src="https://github.com/user-attachments/assets/5d09bdf2-9aa7-448c-bfd3-22ad045017f1" />

<img width="1920" height="1272" alt="Image" src="https://github.com/user-attachments/assets/cca7a7c5-459d-439a-8321-523b6427b213" />

### **Chống xếp hàng chéo:** Đang chờ sự kiện A, bấm mua sự kiện B -> Hiện Modal cảnh báo. Bấm "Rời cũ" -> Hủy A, bắt đầu chờ B.

<img width="1920" height="3318" alt="Image" src="https://github.com/user-attachments/assets/9ba42fc7-a04c-4159-ac6a-39a79dcf71f9" />

### **Grace Period (Tới lượt):** Nhận được trạng thái `active` -> Bắt đầu đếm ngược 60s. Bấm "Vào chọn ghế" -> Gọi API `/confirm` -> Chuyển sang `/seats`.

<img width="1920" height="1272" alt="image" src="https://github.com/user-attachments/assets/9124835a-81a9-4508-9353-76b8f1ac02be" />

<img width="1920" height="2342" alt="Image" src="https://github.com/user-attachments/assets/6fbc42a0-8fd4-4e53-ab42-063c53485a16" />

###  **Bảo vệ phiên chọn ghế (Holding):** Khi đang ở `/seats`, lỡ tay bấm sang Trang chủ -> Widget cảnh báo "Đang có phiên chọn ghế" hiện lên đếm ngược 5 phút.

<img width="1893" height="902" alt="Image" src="https://github.com/user-attachments/assets/671beefc-d371-45bc-acb2-7e10f480f1c9" />

### Thời gian đếm ngược khi chọn ghế 
<img width="1920" height="1367" alt="image" src="https://github.com/user-attachments/assets/4320abe1-97cb-4c30-b9a4-7e062aa114cc" />

### Kéo thả Widget
<img width="1920" height="2342" alt="image" src="https://github.com/user-attachments/assets/8507a98b-a23d-4c6a-8a01-879f3201f3fe" />

### Thiết kế UI Mobile
<img width="456" height="610" alt="image" src="https://github.com/user-attachments/assets/6d2c855b-7b41-4be1-8d4f-e20bc818b3fe" />
<img width="458" height="618" alt="image" src="https://github.com/user-attachments/assets/46cfce94-1905-4b09-bff2-f521e9753835" />
<img width="457" height="617" alt="image" src="https://github.com/user-attachments/assets/f9becb74-940e-4840-ac24-08b873dd0a54" />

### Thu gọn Widget trong UI Mobile 
<img width="459" height="617" alt="image" src="https://github.com/user-attachments/assets/54906dbe-db2a-4a83-bc60-b35073f9a102" />
<img width="462" height="628" alt="image" src="https://github.com/user-attachments/assets/eb2e1b19-cd39-43f1-ac5c-cd9cc5b80f15" />
<img width="452" height="619" alt="image" src="https://github.com/user-attachments/assets/21964f8d-6e9c-4713-a67e-df76e51e25d9" />


## Checklist

- [x] Code chạy không lỗi (`bun run dev`)
- [x] TypeScript check pass (`bun run check`)
- [x] Lint pass (`bun run lint`)
- [x] Đã format code (`bun run format`)
- [x] Đã test thủ công chức năng
- [x] Commit message đúng convention (`feat:`, `fix:`, `chore:`,...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual queue system with real-time status, positions and a dedicated queue page
  * Floating, draggable queue widget shown across customer pages with minimize/dock behavior
  * Cross-queue confirmation modal when switching events
  * Ready/holding/waiting UI components with per-second countdowns and holding session during seat selection
  * Persistent queue state across reloads (localStorage/sessionStorage)
  * API to cancel/leave a queue from the client

* **Bug Fixes**
  * Ensured queue slot cleanup on logout and after successful checkout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->